### PR TITLE
SWITCHYARD-411 make path of quickstarts a property for jboss-as6/jboss-as

### DIFF
--- a/jboss-as6/standalone/dist/assembly.xml
+++ b/jboss-as6/standalone/dist/assembly.xml
@@ -65,7 +65,7 @@
             <outputDirectory>/${switchyard.root.dir}</outputDirectory>
         </fileSet>
         <fileSet>
-          <directory>../../quickstarts</directory>
+          <directory>${quickstarts.dir}</directory>
           <outputDirectory>${switchyard.root.dir}/quickstarts</outputDirectory>
           <excludes>
             <exclude>**/.git</exclude>

--- a/jboss-as7/standalone/dist/assembly.xml
+++ b/jboss-as7/standalone/dist/assembly.xml
@@ -66,7 +66,7 @@
             <directoryMode>755</directoryMode>
         </fileSet>
         <fileSet>
-            <directory>../../quickstarts</directory>
+            <directory>${quickstarts.dir}</directory>
             <outputDirectory>${distro.root.dir}quickstarts</outputDirectory>
             <excludes>
                 <exclude>**/.git</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
 
     <properties>
         <version.distro>0.3</version.distro>
+        <!-- #note# relative path must be started from release/jboss-as7/standalone/dist -->
+        <quickstarts.dir>../../../../quickstarts</quickstarts.dir>
     </properties>
 
     <modules>


### PR DESCRIPTION
SWITCHYARD-411 make path of quickstarts a property for jboss-as6/jboss-as7 distribution

Now you can override with -Dquickstarts.dir="../your-quickstarts" on mvn build of release.
