### PR TITLE
SWITCHYARD-349: Move the Camel CDI Registry code out into a module of its

### DIFF
--- a/jboss-as7/modules/pom.xml
+++ b/jboss-as7/modules/pom.xml
@@ -192,6 +192,11 @@
             <artifactId>switchyard-component-camel-as7</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.switchyard.components</groupId>
+            <artifactId>switchyard-component-camel-cdi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--<dependency>-->
             <!--<groupId>org.switchyard.components</groupId>-->
             <!--<artifactId>switchyard-component-clojure</artifactId>-->

--- a/jboss-as7/modules/src/main/resources/switchyard/components/camel/assembly.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/camel/assembly.xml
@@ -15,6 +15,7 @@
             <includes>
                 <include>org.switchyard.components:switchyard-component-camel</include>
                 <include>org.switchyard.components:switchyard-component-camel-as7</include>
+                <include>org.switchyard.components:switchyard-component-camel-cdi</include>
             </includes>
             <outputDirectory>/modules/org/switchyard/component/camel/main</outputDirectory>
             <outputFileNameMapping>${artifact.artifactId}-${project.version}.${artifact.extension}</outputFileNameMapping>

--- a/jboss-as7/modules/src/main/resources/switchyard/components/camel/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/camel/resources/module.xml
@@ -27,6 +27,7 @@
     <resources>
         <resource-root path="switchyard-component-camel-${project.version}.jar"/>
         <resource-root path="switchyard-component-camel-as7-${project.version}.jar"/>
+        <resource-root path="switchyard-component-camel-cdi-${project.version}.jar"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
SWITCHYARD-349: Move the Camel CDI Registry code out into a module of its own

https://issues.jboss.org/browse/SWITCHYARD-349
