### PR TITLE
SWITCHYARD-373 populate admin model with system components

### DIFF
--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardModelConstants.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardModelConstants.java
@@ -59,6 +59,10 @@ public final class SwitchYardModelConstants {
     
     // nodes
     /**
+     * Constant for model key: activationTypes.
+     */
+    public static final String ACTIVATION_TYPES = "activationTypes";
+    /**
      * Constant for model key: application.
      */
     public static final String APPLICATION = "application";
@@ -70,10 +74,6 @@ public final class SwitchYardModelConstants {
      * Constant for model key: componentServices.
      */
     public static final String COMPONENT_SERVICES = "componentServices";
-    /**
-     * Constant for model key: config-schema.
-     */
-    public static final String CONFIG_SCHEMA = "configSchema";
     /**
      * Constant for model key: configuration.
      */

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemAdd.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemAdd.java
@@ -123,13 +123,18 @@ public final class SwitchYardSubsystemAdd extends AbstractBoottimeAddStepHandler
         componentServiceBuilder.setInitialMode(Mode.ACTIVE);
         newControllers.add(componentServiceBuilder.install());
 
-        // TODO: introspect switchyard version
-        final String version = "0.2.0";
+        final String version = getSwitchYardVersion();
         final SwitchYardAdminService adminService = new SwitchYardAdminService(version);
         newControllers.add(context.getServiceTarget().addService(SwitchYardAdminService.SERVICE_NAME, adminService)
+                .addDependency(SwitchYardComponentService.SERVICE_NAME, List.class, adminService.getComponents())
+                .addDependency(SwitchYardInjectorService.SERVICE_NAME, Map.class, adminService.getSocketBindings())
                 .install());
 
         // Add the AS7 Service for the ServiceDomainManager...
         newControllers.add(context.getServiceTarget().addService(SwitchYardServiceDomainManagerService.SERVICE_NAME, new SwitchYardServiceDomainManagerService()).install());
+    }
+    
+    private String getSwitchYardVersion() {
+        return getClass().getPackage().getImplementationVersion();
     }
 }

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemProviders.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemProviders.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMESPACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REPLY_PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TAIL_COMMENT_ALLOWED;
@@ -35,7 +36,6 @@ import static org.switchyard.as7.extension.SwitchYardModelConstants.APPLICATION;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.APPLICATION_NAME;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.COMPONENT_SERVICES;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.CONFIGURATION;
-import static org.switchyard.as7.extension.SwitchYardModelConstants.CONFIG_SCHEMA;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.FROM;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.GATEWAYS;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.GET_VERSION;
@@ -53,6 +53,7 @@ import static org.switchyard.as7.extension.SwitchYardModelConstants.SERVICES;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.SERVICE_NAME;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.TO;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.TRANSFORMERS;
+import static org.switchyard.as7.extension.SwitchYardModelConstants.ACTIVATION_TYPES;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -220,11 +221,6 @@ final class SwitchYardSubsystemProviders {
             op.get(OPERATION_NAME).set(LIST_COMPONENTS);
             op.get(DESCRIPTION).set(bundle.getString("switchyard.list-components"));
 
-            op.get(REQUEST_PROPERTIES, TYPE, TYPE).set(ModelType.STRING);
-            op.get(REQUEST_PROPERTIES, TYPE, DESCRIPTION)
-                    .set(bundle.getString("switchyard.list-components.param.type"));
-            op.get(REQUEST_PROPERTIES, TYPE, NILLABLE).set(true);
-
             op.get(REPLY_PROPERTIES, TYPE).set(ModelType.LIST);
             op.get(REPLY_PROPERTIES, DESCRIPTION).set(bundle.getString("switchyard.list-components.reply"));
             op.get(REPLY_PROPERTIES, VALUE_TYPE).set(ModelType.STRING);
@@ -305,21 +301,20 @@ final class SwitchYardSubsystemProviders {
             op.get(REQUEST_PROPERTIES, NAME, TYPE).set(ModelType.STRING);
             op.get(REQUEST_PROPERTIES, NAME, DESCRIPTION).set(bundle.getString("switchyard.read-component.param.name"));
             op.get(REQUEST_PROPERTIES, NAME, NILLABLE).set(true);
-            op.get(REQUEST_PROPERTIES, TYPE, TYPE).set(ModelType.STRING);
-            op.get(REQUEST_PROPERTIES, TYPE, DESCRIPTION).set(bundle.getString("switchyard.read-component.param.type"));
-            op.get(REQUEST_PROPERTIES, TYPE, NILLABLE).set(true);
 
             op.get(REPLY_PROPERTIES, TYPE).set(ModelType.LIST);
             op.get(REPLY_PROPERTIES, DESCRIPTION).set(bundle.getString("switchyard.read-component.reply"));
             op.get(REPLY_PROPERTIES, VALUE_TYPE, NAME, TYPE).set(ModelType.STRING);
             op.get(REPLY_PROPERTIES, VALUE_TYPE, NAME, DESCRIPTION).set(
                     bundle.getString("switchyard.read-component.reply.name"));
-            op.get(REPLY_PROPERTIES, VALUE_TYPE, TYPE, TYPE).set(ModelType.STRING);
-            op.get(REPLY_PROPERTIES, VALUE_TYPE, TYPE, DESCRIPTION).set(
-                    bundle.getString("switchyard.read-component.reply.type"));
-            op.get(REPLY_PROPERTIES, VALUE_TYPE, CONFIG_SCHEMA, TYPE).set(ModelType.STRING);
-            op.get(REPLY_PROPERTIES, VALUE_TYPE, CONFIG_SCHEMA, DESCRIPTION).set(
-                    bundle.getString("switchyard.read-component.reply.config-schema"));
+            op.get(REPLY_PROPERTIES, VALUE_TYPE, ACTIVATION_TYPES, TYPE).set(ModelType.LIST);
+            op.get(REPLY_PROPERTIES, VALUE_TYPE, ACTIVATION_TYPES, DESCRIPTION).set(
+                    bundle.getString("switchyard.read-component.reply.types"));
+            op.get(REPLY_PROPERTIES, VALUE_TYPE, ACTIVATION_TYPES, VALUE_TYPE, TYPE).set(ModelType.STRING);
+            op.get(REPLY_PROPERTIES, VALUE_TYPE, PROPERTIES, TYPE).set(ModelType.LIST);
+            op.get(REPLY_PROPERTIES, VALUE_TYPE, PROPERTIES, DESCRIPTION).set(
+                    bundle.getString("switchyard.read-component.reply.properties"));
+            op.get(REPLY_PROPERTIES, VALUE_TYPE, PROPERTIES, VALUE_TYPE, TYPE).set(ModelType.PROPERTY);
 
             return op;
         }

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/admin/ModelNodeCreationUtil.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/admin/ModelNodeCreationUtil.java
@@ -20,11 +20,11 @@ package org.switchyard.as7.extension.admin;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.APPLICATION;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.COMPONENT_SERVICES;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.CONFIGURATION;
-import static org.switchyard.as7.extension.SwitchYardModelConstants.CONFIG_SCHEMA;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.FROM;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.GATEWAYS;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.IMPLEMENTATION;
@@ -34,6 +34,10 @@ import static org.switchyard.as7.extension.SwitchYardModelConstants.REFERENCES;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.SERVICES;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.TO;
 import static org.switchyard.as7.extension.SwitchYardModelConstants.TRANSFORMERS;
+import static org.switchyard.as7.extension.SwitchYardModelConstants.ACTIVATION_TYPES;
+
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.dmr.ModelNode;
 import org.switchyard.admin.Application;
@@ -262,7 +266,7 @@ final public class ModelNodeCreationUtil {
      * has the form: <br>
      * <code><pre>
      *      "name" =&gt; "componentName"
-     *      "type" =&gt; "GATEWAY"
+     *      "activationTypes" =&gt; ["soap"]
      *      "configSchema" =&gt; "&lt;?xml ..."
      * </pre></code>
      * 
@@ -272,8 +276,24 @@ final public class ModelNodeCreationUtil {
     public static ModelNode createComponentNode(Component component) {
         ModelNode componentNode = new ModelNode();
         componentNode.get(NAME).set(component.getName());
-        componentNode.get(TYPE).set(component.getType().toString());
-        componentNode.get(CONFIG_SCHEMA).set(component.getConfigSchema());
+        
+        Set<String> types = component.getTypes();
+        if (types == null || types.isEmpty()) {
+            componentNode.get(ACTIVATION_TYPES).addEmptyList();
+        } else {
+            for (String type : types) {
+                componentNode.get(ACTIVATION_TYPES).add(type);
+            }
+        }
+        
+        Map<String,String> properties = component.getProperties();
+        if (properties == null || properties.isEmpty()) {
+            componentNode.get(PROPERTIES);
+        } else {
+            for (Map.Entry<String,String> property : properties.entrySet()) {
+                componentNode.get(PROPERTIES).get(property.getKey()).set(property.getValue());
+            }
+        }
         return componentNode;
     }
 

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/admin/SwitchYardSubsystemListComponents.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/admin/SwitchYardSubsystemListComponents.java
@@ -18,18 +18,12 @@
  */
 package org.switchyard.as7.extension.admin;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
-
-import java.util.EnumSet;
-import java.util.Set;
-
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.switchyard.admin.Component;
-import org.switchyard.admin.ComponentType;
 import org.switchyard.admin.SwitchYard;
 import org.switchyard.as7.extension.services.SwitchYardAdminService;
 
@@ -70,17 +64,8 @@ public final class SwitchYardSubsystemListComponents implements OperationStepHan
                         SwitchYardAdminService.SERVICE_NAME);
 
                 SwitchYard switchYard = SwitchYard.class.cast(controller.getService().getValue());
-                Set<ComponentType> desiredComponentTypes;
-                if (operation.hasDefined(TYPE) && !"all".equalsIgnoreCase(operation.get(TYPE).asString())) {
-                    desiredComponentTypes = EnumSet.of(ComponentType.valueOf(operation.get(TYPE).asString()
-                            .toUpperCase()));
-                } else {
-                    desiredComponentTypes = EnumSet.allOf(ComponentType.class);
-                }
                 for (Component component : switchYard.getComponents()) {
-                    if (desiredComponentTypes.contains(component.getType())) {
-                        components.add(component.getName());
-                    }
+                    components.add(component.getName());
                 }
                 context.completeStep();
             }

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/admin/SwitchYardSubsystemReadComponent.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/admin/SwitchYardSubsystemReadComponent.java
@@ -19,10 +19,6 @@
 package org.switchyard.as7.extension.admin;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
-
-import java.util.EnumSet;
-import java.util.Set;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -30,7 +26,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.switchyard.admin.Component;
-import org.switchyard.admin.ComponentType;
 import org.switchyard.admin.SwitchYard;
 import org.switchyard.as7.extension.services.SwitchYardAdminService;
 
@@ -79,17 +74,8 @@ public final class SwitchYardSubsystemReadComponent implements OperationStepHand
                         components.add(ModelNodeCreationUtil.createComponentNode(component));
                     }
                 } else {
-                    Set<ComponentType> desiredComponentTypes;
-                    if (operation.hasDefined(TYPE) && !"all".equalsIgnoreCase(operation.get(TYPE).asString())) {
-                        desiredComponentTypes = EnumSet.of(ComponentType.valueOf(operation.get(TYPE).asString()
-                                .toUpperCase()));
-                    } else {
-                        desiredComponentTypes = EnumSet.allOf(ComponentType.class);
-                    }
                     for (Component component : switchYard.getComponents()) {
-                        if (desiredComponentTypes.contains(component.getType())) {
-                            components.add(ModelNodeCreationUtil.createComponentNode(component));
-                        }
+                        components.add(ModelNodeCreationUtil.createComponentNode(component));
                     }
                 }
                 context.completeStep();

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/deployment/SwitchYardDeploymentProcessor.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/deployment/SwitchYardDeploymentProcessor.java
@@ -34,7 +34,9 @@ import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.ImmediateValue;
+import org.switchyard.admin.SwitchYard;
 import org.switchyard.as7.extension.SwitchYardDeploymentMarker;
+import org.switchyard.as7.extension.services.SwitchYardAdminService;
 import org.switchyard.as7.extension.services.SwitchYardComponentService;
 import org.switchyard.as7.extension.services.SwitchYardService;
 import org.switchyard.as7.extension.services.SwitchYardServiceDomainManagerService;
@@ -73,6 +75,7 @@ public class SwitchYardDeploymentProcessor implements DeploymentUnitProcessor {
         final ServiceName switchyardServiceName = deploymentUnit.getServiceName().append(SwitchYardService.SERVICE_NAME);
         final ServiceBuilder<SwitchYardDeployment> switchyardServiceBuilder = serviceTarget.addService(switchyardServiceName, container);
         switchyardServiceBuilder.addDependency(SwitchYardComponentService.SERVICE_NAME, List.class, container.getComponents());
+        switchyardServiceBuilder.addDependency(SwitchYardAdminService.SERVICE_NAME, SwitchYard.class, container.getSwitchYard());
 
         final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION);
         if (moduleDescription != null) {

--- a/jboss-as7/extension/src/main/resources/org/switchyard/as7/extension/LocalDescriptions.properties
+++ b/jboss-as7/extension/src/main/resources/org/switchyard/as7/extension/LocalDescriptions.properties
@@ -12,7 +12,6 @@ switchyard.list-applications.reply=The names of all known SwitchYard application
 
 # list-components operation
 switchyard.list-components=Operation returning the names of components registered with the SwitchYard subsystem.
-switchyard.list-components.param.type=Only return components of the specified type.  Can be one of: implementation, gateway, or all (default).
 switchyard.list-components.reply=The names of all known SwitchYard components.
 
 # list-services operation
@@ -43,11 +42,10 @@ switchyard.read-service.reply.references.interface=The referenced interface.
 # read-component operation
 switchyard.read-component=Operation returning details for the specified components.  If name is specified, type is ignored and details for the named component are returned.  If name is not specified, but type is specified, details for all components of the specified type are returned.  If no name or type are specified, details are returned for all components known to the SwitchYard subsystem.
 switchyard.read-component.param.name=The name of the component.
-switchyard.read-component.param.type=The type of the components.  Can be one of: implementation or gateway.
 switchyard.read-component.reply=A list of components.
 switchyard.read-component.reply.name=The component's name.
-switchyard.read-component.reply.type=The component's type.
-switchyard.read-component.reply.config-schema=The configuration schema specified by the component.
+switchyard.read-component.reply.types=The activation types supported by this component.
+switchyard.read-component.reply.properties=The property values defined for this component.
 
 # read-application operation
 switchyard.read-application=Operation returning details for the specified application.  If name is not specified, but type is specified, details are returned for all applications known to the SwitchYard subsystem.


### PR DESCRIPTION
added code to populate Component API in the admin model.
also snuck in a change to dynamically detect the switchyard runtime version (was hard-coded).
