### PR TITLE
SWITCHYARD-530 fix deployment exceptions related to name binding

### DIFF
--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/deployment/SwitchYardDeploymentProcessor.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/deployment/SwitchYardDeploymentProcessor.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.naming.context.NamespaceContextSelector;
+import org.jboss.as.naming.deployment.JndiNamingDependencyProcessor;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -76,6 +77,8 @@ public class SwitchYardDeploymentProcessor implements DeploymentUnitProcessor {
         final ServiceBuilder<SwitchYardDeployment> switchyardServiceBuilder = serviceTarget.addService(switchyardServiceName, container);
         switchyardServiceBuilder.addDependency(SwitchYardComponentService.SERVICE_NAME, List.class, container.getComponents());
         switchyardServiceBuilder.addDependency(SwitchYardAdminService.SERVICE_NAME, SwitchYard.class, container.getSwitchYard());
+        // ensure naming context is fully initialized before we start
+        switchyardServiceBuilder.addDependency(JndiNamingDependencyProcessor.serviceName(deploymentUnit));
 
         final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION);
         if (moduleDescription != null) {


### PR DESCRIPTION
ensure the jndi context is properly initialized before starting the switchyard deployment service.
ensure any beans contributed by the switchyard deployment are available for web applications by ensuring the switchyard deployment service is started before the web deployment service.
