### PR TITLE
SWITCHYARD-561

### DIFF
--- a/docs/gettingstarted/src/main/docbook/en-US/Book_Info.xml
+++ b/docs/gettingstarted/src/main/docbook/en-US/Book_Info.xml
@@ -2,14 +2,14 @@
 <!DOCTYPE bookinfo PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <bookinfo id="booki-Getting_Started">
   <title>Getting Started Guide</title>
-  <subtitle>Getting Started with JBoss SwitchYard 0.1</subtitle>
+  <subtitle>Getting Started with JBoss SwitchYard 0.3.0</subtitle>
   <productname>JBoss SwitchYard</productname>
-  <productnumber>0.1</productnumber>
-  <edition>0.1</edition>
-  <pubsnumber>0.1</pubsnumber>
+  <productnumber>0.3</productnumber>
+  <edition>0.3</edition>
+  <pubsnumber>0.3</pubsnumber>
   <!--<abstract>-->
     <!--<para>-->
-      <!--Getting Started Guide for JBoss SwitchYard v0.1.0-->
+      <!--Getting Started Guide for JBoss SwitchYard v0.3.0-->
     <!--</para>-->
   <!--</abstract>-->
   <!--<corpauthor>-->

--- a/docs/gettingstarted/src/main/docbook/en-US/chapter-1-Installing_SwitchYard_Server.xml
+++ b/docs/gettingstarted/src/main/docbook/en-US/chapter-1-Installing_SwitchYard_Server.xml
@@ -7,18 +7,10 @@
       
       <title>Overview</title>
       <para>This section of the guide provides basic details on how to install the SwitchYard distribution on your system.</para>
-      <para>Two SwitchYard distributions are available pre-installed in JBoss Application Server (AS):</para>
       <itemizedlist>
         <listitem>
           <para>
-            SwitchYard AS6:  This distribution is based on the Version 6.0.0.Final of the
-            <ulink url="http://www.jboss.org/jbossas/">JBoss Application Server</ulink>
-            .
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            SwitchYard AS7:  This distribution is based on the Version 7.0.0.Beta3 of the
+            SwitchYard AS7:  This distribution is based on the Version 7.0.2.Final of the
             <emphasis role="color:#1e3349">
               <ulink url="http://www.jboss.org/jbossas/">JBoss Application Server</ulink>
             </emphasis>
@@ -27,7 +19,7 @@
         </listitem>
       </itemizedlist>
       <para>
-        Both versions of SwitchYard can be
+        SwitchYard can be
         <ulink url="http://www.jboss.org/switchyard/downloads">downloaded from JBoss</ulink>
         .
       </para>
@@ -48,37 +40,6 @@
           </para>
         </listitem>
       </orderedlist>
-    </section>
-    <section id="sid-2883612_InstallingSwitchYardServer-InstallingSwitchYardAS6">
-      
-      <title>Installing SwitchYard AS6</title>
-      <para>
-        Download the
-        <ulink url="http://www.jboss.org/switchyard/downloads">SwitchYard Distribution Zip file</ulink>
-        and simply unzip it into a suitable location on your file system.
-      </para>
-      <important>
-        <para>It is not mandatory to configure $JBOSS_HOME on your system, but if you already have it configured you will need to reset it to point to the root of the unzipped SwitchYard AS6 distribution.</para>
-      </important>
-      <para>
-        <emphasis role="color:#333333">After unzipping the distribution you should see the following structure on your file system.</emphasis>
-      </para>
-      <para>
-        <figure>
-<title>TODO InformalFigure image title empty</title>
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="author/download/attachments/2883612/Screen+shot+2011-06-10+at+11.00.51.png"/>
-            </imageobject>
-          </mediaobject>
-        </figure>
-        
-        To start the SwitchYard AS instance simply open a command terminal, change directory into the distribution bin directory and execute the "run" command script (
-        <emphasis role="italics">run.sh</emphasis>
-        on Unix/Linux/MacOS and
-        <emphasis role="italics">run.bat</emphasis>
-        on Windows).
-      </para>
     </section>
     <section id="sid-2883612_InstallingSwitchYardServer-InstallingSwitchYardAS7">
       

--- a/docs/gettingstarted/src/main/docbook/en-US/chapter-2-Quickstarts.xml
+++ b/docs/gettingstarted/src/main/docbook/en-US/chapter-2-Quickstarts.xml
@@ -4,7 +4,7 @@
     
     <title>Quickstarts</title>
     <para>
-      The easiest way to get started with testing an application on SwitchYard is to take one of the distribution's Quickstart examples and run it.  The AS6 and AS7 distributions both contain a
+      The easiest way to get started with testing an application on SwitchYard is to take one of the distribution's Quickstart examples and run it.  The AS7 distribution contains a
       <emphasis role="italics">quickstarts</emphasis>
       folder as follows.
     </para>

--- a/docs/gettingstarted/src/main/docbook/en-US/chapter-3-Installing_Forge_Tooling.xml
+++ b/docs/gettingstarted/src/main/docbook/en-US/chapter-3-Installing_Forge_Tooling.xml
@@ -10,12 +10,12 @@
       .  Make sure you setup the $FORGE_HOME environment variable.
     </para>
     <para>
-      Once Forge is installed it's time to install the SwitchYard extensions to Forge.  These are located in the forge directory within the SwitchYard distribution.  Simply copy these jars into the
-      <emphasis role="italics">$FORGE_HOME/lib</emphasis>
-      directory.
+      Once Forge is installed it's time to install the SwitchYard extensions to Forge.  Download the SwitchYard Installer distribution, and either :
+      <emphasis role="italics">ant install</emphasis>
+     which will install the SwitchYard AS7 distribution to your AS7 server and
+ask whether you want to install the SwitchYard Console. If you only want to 
+install the SwitchYard Forge tooling : 
+      <emphasis role="italics">ant install-forge</emphasis> 
     </para>
-    <informalexample>
-      <programlisting>cp forge/*.jar $FORGE_HOME/lib</programlisting>
-    </informalexample>
     <para>For more details on using the Forge tooling for SwitchYard, please see the User Guide.</para>
   </chapter>

--- a/docs/userguide/src/main/docbook/en-US/Book_Info.xml
+++ b/docs/userguide/src/main/docbook/en-US/Book_Info.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE bookinfo PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <bookinfo id="booki-User_Guide">
   <title>User Guide</title>
-  <subtitle>User Guide for SwitchYard 0.1</subtitle>
+  <subtitle>User Guide for SwitchYard 0.3.0</subtitle>
   <productname>JBoss SwitchYard</productname>
-  <productnumber>0.1</productnumber>
+  <productnumber>0.3</productnumber>
   <edition>0.1</edition>
   <pubsnumber>0.1</pubsnumber>
   <!--<abstract>-->

--- a/docs/userguide/src/main/docbook/en-US/chapter-8-Tooling.xml
+++ b/docs/userguide/src/main/docbook/en-US/chapter-8-Tooling.xml
@@ -12,13 +12,16 @@
         <title>Creating a Project</title>
         <para>The first thing you'll want to do with Forge is create a new project.  This can be done inside the Forge shell using the new-project command.</para>
         <informalexample>
-          <programlisting>$ forge
-   ____                          _____                   
-  / ___|  ___  __ _ _ __ ___    |  ___|__  _ __ __ _  ___
-  \___ \ / _ \/ _` | '_ ` _ \   | |_ / _ \| '__/ _` |/ _ \  \\
-   ___) |  __/ (_| | | | | | |  |  _| (_) | | | (_| |  __/  //
-  |____/ \___|\__,_|_| |_| |_|  |_|  \___/|_|  \__, |\___|
-                                                |___/     
+          <programlisting>tcunning@localhost:~]$ forge
+log4j:WARN No appenders could be found for logger (org.jboss.weld.Version).
+log4j:WARN Please initialize the log4j system properly.
+log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
+    _____                    
+   |  ___|__  _ __ __ _  ___ 
+   | |_ / _ \| `__/ _` |/ _ \  \\
+   |  _| (_) | | | (_| |  __/  //
+   |_|  \___/|_|  \__, |\___| 
+                   |___/      
 
 [no project] tmp $ new-project --named syApp --topLevelPackage org.switchyard.examples.forge
 Use [/private/tmp/syApp] as project directory? [Y/n]
@@ -56,15 +59,29 @@ Wrote /private/tmp/syApp/src/main/resources/META-INF/forge.xml
               - commands and dependencies for Camel services and gateway bindings
             </para>
           </listitem>
+          <listitem>
+            <para>
+              <emphasis role="strong">switchyard.rules</emphasis>
+              - commands and dependencies for Drools services
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis role="strong">switchyard.bpm</emphasis>
+              - commands and dependencies for JBPM services
+            </para>
+          </listitem>
         </itemizedlist>
         <para>
           Installing a facet can be done directly in the shell using the
           <code>install-facet</code>
-          command.
+          command.   
         </para>
         <informalexample>
           <programlisting>[syapp] syapp $ project install-facet switchyard.soap
-***SUCCESS*** Installed [switchyard.soap] successfully.</programlisting>
+***SUCCESS*** Installed [switchyard.soap] successfully.
+Wrote /tmp/foo/pom.xml
+	  </programlisting>
         </informalexample>
       </section>
       <section id="sid-2654318_Forge-Commands">
@@ -79,8 +96,8 @@ Wrote /private/tmp/syApp/src/main/resources/META-INF/forge.xml
         <itemizedlist>
           <listitem>
             <para>
-              <code>switchyard show-confi</code>
-              g : displays the current state of your application's configuration, including services, references, and bindings.
+              <code>switchyard show-config</code>
+              : displays the current state of your application's configuration, including services, references, and bindings.
             </para>
           </listitem>
           <listitem>
@@ -91,8 +108,7 @@ Wrote /private/tmp/syApp/src/main/resources/META-INF/forge.xml
           </listitem>
           <listitem>
             <para>
-              s
-              <code>witchyard promote-reference</code>
+              <code>switchyard promote-reference</code>
               : promotes an internal application-scoped reference so that it can be mapped to services provided in other applications.
             </para>
           </listitem>
@@ -149,9 +165,34 @@ Wrote /private/tmp/syApp/src/main/resources/META-INF/forge.xml
           </listitem>
           <listitem>
             <para>
-              s
-              <code>oap-binding bind-reference</code>
+              <code>soap-binding bind-reference</code>
               : binds a reference to a SOAP endpoint.
+            </para>
+          </listitem>
+        </itemizedlist>
+        <para>
+          <emphasis role="strong">
+            <emphasis role="italics">switchyard.rules</emphasis>
+          </emphasis>
+        </para>
+        <itemizedlist>
+          <listitem>
+            <para>
+              <code>rules-service create</code>
+	      : creates a new Rules service, consisting of a service interface and implementation class.
+            </para>
+          </listitem>
+        </itemizedlist>
+        <para>
+          <emphasis role="strong">
+            <emphasis role="italics">switchyard.bpm</emphasis>
+          </emphasis>
+        </para>
+        <itemizedlist>
+          <listitem>
+            <para>
+              <code>bpm-service create</code>
+              : creates a new BPM service, consisting of a service interface and implementation class.
             </para>
           </listitem>
         </itemizedlist>


### PR DESCRIPTION
Upgrade the docs for the 0.3 release.   Remove references to the AS 6
distribution, which was discontinued as of 0.3.    Change version numbers,
change the Forge documentation to reflect the new installer.
