### PR TITLE
SWITCHYARD-582 Bump arquillian timeout to 120s in release tests

### DIFF
--- a/jboss-as7/standalone/dist/src/test/resources/arquillian.xml
+++ b/jboss-as7/standalone/dist/src/test/resources/arquillian.xml
@@ -6,6 +6,7 @@
 
     <container qualifier="jboss7" default="true"> 
         <configuration>
+    	    <property name="startupTimeoutInSeconds">120</property>
 	        <property name="serverConfig">${switchyard.jboss.home}standalone/configuration/standalone-preview.xml</property>
         </configuration>
     </container>

--- a/jboss-as7/tests/pom.xml
+++ b/jboss-as7/tests/pom.xml
@@ -35,11 +35,6 @@
     <name>SwitchYard: AS7 Release Distribution Tests</name>
     <description>SwitchYard AS7 Release Distribution Tests</description>
 
-    <properties>
-        <version.jbossas>7.0.2.Final</version.jbossas>
-        <version.arquillian>1.0.0.CR1</version.arquillian>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.switchyard</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-582
