### PR TITLE
SWITCHYARD-528

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard</groupId>
+                <artifactId>switchyard-forge-clojure-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.switchyard</groupId>
                 <artifactId>switchyard-forge-soap-plugin</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/tools/forge/assembly.xml
+++ b/tools/forge/assembly.xml
@@ -45,9 +45,7 @@
               <include>org.switchyard:switchyard-forge-bean-plugin</include>
               <include>org.switchyard:switchyard-forge-bpm-plugin</include>
               <include>org.switchyard:switchyard-forge-camel-plugin</include>
-              <!-- 
               <include>org.switchyard:switchyard-forge-clojure-plugin</include>
-              -->
               <include>org.switchyard:switchyard-forge-common</include>
               <include>org.switchyard:switchyard-forge-plugin</include>
               <include>org.switchyard:switchyard-forge-rules-plugin</include>
@@ -64,9 +62,11 @@
             <includes>
               <include>org.switchyard:switchyard-api</include>
               <include>org.switchyard:switchyard-common</include>
+              <include>org.switchyard.components:switchyard-component-clojure</include>
               <include>org.switchyard:switchyard-config</include>
               <include>org.switchyard:switchyard-deploy</include>
               <include>org.switchyard:switchyard-transform</include>
+              <include>org.switchyard:switchyard-validate</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/tools/forge/pom.xml
+++ b/tools/forge/pom.xml
@@ -58,6 +58,11 @@
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-forge-soap-plugin</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-forge-clojure-plugin</artifactId>
+        </dependency>
+
 
         <!-- dependencies -->
         <dependency>
@@ -68,6 +73,12 @@
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.switchyard.components</groupId>
+            <artifactId>switchyard-component-clojure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-config</artifactId>
@@ -83,6 +94,10 @@
         <dependency>
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-transform</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-validate</artifactId>
         </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>

--- a/tools/forge/src/main/resources/dependencies/module.xml
+++ b/tools/forge/src/main/resources/dependencies/module.xml
@@ -15,6 +15,8 @@
     <resource-root path="switchyard-config-${project.version}.jar"/>
     <resource-root path="switchyard-deploy-${project.version}.jar"/>
     <resource-root path="switchyard-transform-${project.version}.jar"/>
+    <resource-root path="switchyard-validate-${project.version}.jar"/>
+    <resource-root path="switchyard-component-clojure-${project.version}.jar"/>
   </resources>
   
   <dependencies>

--- a/tools/forge/src/main/resources/module.xml
+++ b/tools/forge/src/main/resources/module.xml
@@ -11,6 +11,7 @@
 	<resource-root path="switchyard-forge-rules-plugin-${project.version}.jar"/>
 	<resource-root path="switchyard-forge-bpm-plugin-${project.version}.jar"/>
 	<resource-root path="switchyard-forge-camel-plugin-${project.version}.jar"/>
+	<resource-root path="switchyard-forge-clojure-plugin-${project.version}.jar"/>
   </resources>
   
   <dependencies>


### PR DESCRIPTION
A related commit removed shading from the clojure plugin.   This adds the clojure plun and adds switchyard-validate and the clojure component which are necessary to use the clojure forge plugin.

Please process the related pull request in components _before_ handling this one.
