### PR TITLE
SWITCHYARD-525: Investigate why module dependencies are required in rules-interview-agent quickstart

### DIFF
--- a/jboss-as7/modules/src/main/resources/switchyard/components/bpm/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/bpm/resources/module.xml
@@ -23,18 +23,18 @@
         <resource-root path="jbpm-bpmn2-xsds-${version.jbpm}.jar"/>
     </resources>
     <dependencies>
-        <module name="javax.api"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.drools.drools-compiler"/>
-        <module name="org.drools.drools-core"/>
-        <module name="org.drools.drools-persistence-jpa"/>
-        <module name="org.drools.knowledge-api"/>
-        <module name="org.jbpm.jbpm-bpmn2"/>
-        <module name="org.jbpm.jbpm-flow"/>
-        <module name="org.jbpm.jbpm-flow-builder"/>
-        <module name="org.jbpm.jbpm-human-task"/>
-        <module name="org.jbpm.jbpm-persistence-jpa"/>
-        <module name="org.jbpm.jbpm-workitems"/>
+        <module name="javax.api" export="true"/>
+        <module name="org.apache.log4j" export="true"/>
+        <module name="org.drools.drools-compiler" export="true"/>
+        <module name="org.drools.drools-core" export="true"/>
+        <module name="org.drools.drools-persistence-jpa" export="true"/>
+        <module name="org.drools.knowledge-api" export="true"/>
+        <module name="org.jbpm.jbpm-bpmn2" export="true"/>
+        <module name="org.jbpm.jbpm-flow" export="true"/>
+        <module name="org.jbpm.jbpm-flow-builder" export="true"/>
+        <module name="org.jbpm.jbpm-human-task" export="true"/>
+        <module name="org.jbpm.jbpm-persistence-jpa" export="true"/>
+        <module name="org.jbpm.jbpm-workitems" export="true"/>
         <module name="org.switchyard.api"/>
         <module name="org.switchyard.common"/>
         <module name="org.switchyard.component.common.rules"/>

--- a/jboss-as7/modules/src/main/resources/switchyard/components/rules/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/rules/resources/module.xml
@@ -22,12 +22,12 @@
         <resource-root path="switchyard-component-rules-${project.version}.jar"/>
     </resources>
     <dependencies>
-        <module name="javax.api"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.drools.drools-compiler"/>
-        <module name="org.drools.drools-core"/>
-        <module name="org.drools.drools-persistence-jpa"/>
-        <module name="org.drools.knowledge-api"/>
+        <module name="javax.api" export="true"/>
+        <module name="org.apache.log4j" export="true"/>
+        <module name="org.drools.drools-compiler" export="true"/>
+        <module name="org.drools.drools-core" export="true"/>
+        <module name="org.drools.drools-persistence-jpa" export="true"/>
+        <module name="org.drools.knowledge-api" export="true"/>
         <module name="org.switchyard.api"/>
         <module name="org.switchyard.common"/>
         <module name="org.switchyard.component.common.rules"/>


### PR DESCRIPTION
Investigate why module dependencies are required in rules-interview-agent quickstart
https://issues.jboss.org/browse/SWITCHYARD-525
