### PR TITLE
SWITCHYARD-226 Camel bindings need to support WSDL interface type

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/camel/jms/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/camel/jms/module.xml
@@ -29,6 +29,7 @@
     </resources>
 
     <dependencies>
+        <module name="javax.api"/>
         <module name="org.apache.camel.core"/>
         <module name="org.apache.camel.spring"/>
         <module name="org.apache.commons.logging"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-226
