### PR TITLE
SWITCHYARD-519: Add Content Based Routing (CBR) support and quickstart

### DIFF
--- a/jboss-as7/pom.xml
+++ b/jboss-as7/pom.xml
@@ -111,6 +111,11 @@
         </dependency>
         <dependency>
             <groupId>org.switchyard.quickstarts</groupId>
+            <artifactId>switchyard-quickstart-rules-camel-cbr</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard.quickstarts</groupId>
             <artifactId>switchyard-quickstart-rules-interview</artifactId>
             <scope>test</scope>
         </dependency>

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/RulesCamelCBRQuickstartTest.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/RulesCamelCBRQuickstartTest.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.test.quickstarts;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.test.ArquillianUtil;
+
+/**
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+public class RulesCamelCBRQuickstartTest {
+
+    @Deployment(testable = false)
+    public static JavaArchive createDeployment() {
+        return ArquillianUtil.createJarQSDeployment("switchyard-quickstart-rules-camel-cbr");
+    }
+
+    @Test
+    public void testDeployment() {
+        Assert.assertNotNull("Dummy not null", "");
+    }
+
+}


### PR DESCRIPTION
SWITCHYARD-519: Add Content Based Routing (CBR) support and quickstart
https://issues.jboss.org/browse/SWITCHYARD-519
