### PR TITLE
Fix to use non-deprecated AS7 API

### DIFF
--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtension.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtension.java
@@ -84,7 +84,8 @@ public class SwitchYardExtension implements Extension {
     /** {@inheritDoc} */
     @Override
     public void initialize(final ExtensionContext context) {
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME,1,0);
+        //todo convert to ResourceDefinition
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(SwitchYardSubsystemProviders.SUBSYSTEM_DESCRIBE);
         registration.registerOperationHandler(ADD, SwitchYardSubsystemAdd.INSTANCE, SwitchYardSubsystemProviders.SUBSYSTEM_ADD, false);
         registration.registerOperationHandler(DESCRIBE, SwitchYardSubsystemDescribe.INSTANCE, SwitchYardSubsystemProviders.SUBSYSTEM_DESCRIBE, false, OperationEntry.EntryType.PRIVATE);


### PR DESCRIPTION
deprecated method registerSubsystem(name) is going to be removed in EAP6/7.1.2 
registerSubsystem(name,majorVersion,minorVersion) should be used instead.
