### PR TITLE
SWITCHYARD-714: Add capability for Context properties to be mapped into BPM task parameters

### DIFF
--- a/jboss-as7/modules/src/main/resources/switchyard/components/common/rules/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/common/rules/resources/module.xml
@@ -31,6 +31,7 @@
         <module name="org.drools.drools-core"/>
         <module name="org.drools.drools-persistence-jpa"/>
         <module name="org.drools.knowledge-api"/>
+        <module name="org.mvel.mvel2"/>
         <module name="org.switchyard.api"/>
         <module name="org.switchyard.common" services="export"/>
         <module name="org.switchyard.config"/>


### PR DESCRIPTION
SWITCHYARD-714: Add capability for Context properties to be mapped into BPM task parameters
https://issues.jboss.org/browse/SWITCHYARD-714
