### PR TITLE
SWITCHYARD-745 Add modules for camel-ftp and dependencies

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/apache/commons/net/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/apache/commons/net/module.xml
@@ -22,10 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.0" name="org.apache.commons.commons-net">
+<module xmlns="urn:jboss:module:1.0" name="org.apache.commons.net">
 
     <resources>
         <resource-root path="commons-net-${version.commons.net}.jar"/>
     </resources>
 
+    <dependencies>
+        <module name="javax.api"/>
+    </dependencies>
 </module>

--- a/jboss-as7/modules/src/main/resources/external/jcraft/jsch/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/jcraft/jsch/module.xml
@@ -28,4 +28,8 @@
         <resource-root path="jsch-${version.jsch}.jar"/>
     </resources>
 
+    <dependencies>
+        <module name="javax.api"/>
+    </dependencies>
+
 </module>

--- a/jboss-as7/pom.xml
+++ b/jboss-as7/pom.xml
@@ -111,6 +111,11 @@
         </dependency>
         <dependency>
             <groupId>org.switchyard.quickstarts</groupId>
+            <artifactId>switchyard-quickstart-camel-ftp-binding</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard.quickstarts</groupId>
             <artifactId>switchyard-quickstart-camel-rest-binding</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Both ftp and sftp works fine. Tested with camel-ftp-binding quickstart.
