### PR TITLE
[SWITCHYARD-958] - Added RESTEasy quickstart dependency

### DIFF
--- a/jboss-as7/pom.xml
+++ b/jboss-as7/pom.xml
@@ -149,6 +149,11 @@
         </dependency>
         <dependency>
             <groupId>org.switchyard.quickstarts</groupId>
+            <artifactId>switchyard-quickstart-rest-binding</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard.quickstarts</groupId>
             <artifactId>switchyard-quickstart-rules-camel-cbr</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-958
