### PR TITLE
SWITCHYARD-1085: missing class exception in execution path view of BPEL ...

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/batik/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/batik/module.xml
@@ -51,6 +51,11 @@
         <module name="org.apache.commons.codec"/>
         <module name="org.apache.commons.logging"/>
         <module name="javax.api" />
+        <system>
+          <paths>
+            <path name="com/sun/image/codec/jpeg"/>
+          </paths>
+       </system>
     </dependencies>
 
 </module>


### PR DESCRIPTION
missing class exception in execution path view of BPEL console.
