### PR TITLE
SWITCHYARD-1115: ClassNotFoundException when using bpm audit

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/drools/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/drools/module.xml
@@ -27,6 +27,7 @@
     </resources>
     <dependencies>
         <module name="com.google.protobuf"/>
+        <module name="com.thoughtworks.xstream"/>
         <module name="javax.api"/>
         <module name="org.antlr.antlr-runtime"/>
         <module name="org.eclipse.jdt.core.compiler.ecj"/>

--- a/jboss-as7/modules/src/main/resources/switchyard/components/common/rules/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/common/rules/resources/module.xml
@@ -26,6 +26,7 @@
     </resources>
     <dependencies>
         <module name="javax.api"/>
+        <module name="org.apache.commons.lang"/>
         <module name="org.apache.log4j"/>
         <module name="org.drools"/>
         <module name="org.mvel.mvel2"/>


### PR DESCRIPTION
SWITCHYARD-1115: ClassNotFoundException when using bpm audit
https://issues.jboss.org/browse/SWITCHYARD-1115
