### PR TITLE
SWITCHYARD-1069: Separate picketlink from core security classes

### DIFF
--- a/jboss-as7/modules/pom.xml
+++ b/jboss-as7/modules/pom.xml
@@ -159,6 +159,10 @@
         </dependency>
         <dependency>
             <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-security-jboss</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
             <artifactId>switchyard-serial</artifactId>
         </dependency>
         <dependency>

--- a/jboss-as7/modules/src/main/resources/switchyard/core/assembly-component.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/core/assembly-component.xml
@@ -196,6 +196,7 @@
             <useTransitiveDependencies>false</useTransitiveDependencies>
             <includes>
                 <include>org.switchyard:switchyard-security</include>
+                <include>org.switchyard:switchyard-security-jboss</include>
             </includes>
             <outputDirectory>/modules/org/switchyard/security/main</outputDirectory>
             <outputFileNameMapping>${artifact.artifactId}-${project.version}.${artifact.extension}

--- a/jboss-as7/modules/src/main/resources/switchyard/core/security/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/core/security/module.xml
@@ -26,6 +26,7 @@
 
     <resources>
         <resource-root path="switchyard-security-${project.version}.jar"/>
+        <resource-root path="switchyard-security-jboss-${project.version}.jar"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
SWITCHYARD-1069: Separate picketlink from core security classes
https://issues.jboss.org/browse/SWITCHYARD-1069
