### PR TITLE
SWITCHYARD-1237: Module dependency missing in drools modules.xml

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/drools/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/drools/module.xml
@@ -40,6 +40,7 @@
         <module name="com.google.protobuf"/>
         <module name="com.thoughtworks.xstream"/>
         <module name="javax.api"/>
+        <module name="javax.enterprise.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>


### PR DESCRIPTION
SWITCHYARD-1237: Module dependency missing in drools modules.xml
https://issues.jboss.org/browse/SWITCHYARD-1237
