### PR TITLE
SWITCHYARD-1227: Detect exception and common XML types in serializer

### DIFF
--- a/jboss-as7/modules/src/main/resources/switchyard/core/serial/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/core/serial/module.xml
@@ -35,6 +35,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.activation.api"/>
+        <module name="org.switchyard.api"/>
         <module name="org.switchyard.common"/>
         <module name="org.apache.log4j"/>
         <module name="org.codehaus.jackson.jackson-core-asl"/>


### PR DESCRIPTION
SWITCHYARD-1227: Detect exception and common XML types in serializer
https://issues.jboss.org/browse/SWITCHYARD-1227
