### PR TITLE
SWITCHYARD-325: Allow developer-defined correlationId to refer to BPM processes in addition to processInstanceId

### DIFF
--- a/jboss-as7/modules/pom.xml
+++ b/jboss-as7/modules/pom.xml
@@ -631,10 +631,6 @@
             <artifactId>drools-persistence-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.drools</groupId>
-            <artifactId>kie-ci</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-bam</artifactId>
         </dependency>
@@ -669,6 +665,10 @@
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-ci</artifactId>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>

--- a/jboss-as7/modules/src/main/resources/external/drools/assembly-component.xml
+++ b/jboss-as7/modules/src/main/resources/external/drools/assembly-component.xml
@@ -37,8 +37,8 @@
         <include>org.drools:drools-compiler</include>
         <include>org.drools:drools-core</include>
         <include>org.drools:drools-persistence-jpa</include>
-        <include>org.drools:kie-ci</include>
         <include>org.kie:kie-api</include>
+        <include>org.kie:kie-ci</include>
         <include>org.kie:kie-internal</include>
         <include>org.kie.commons:kie-commons-data</include>
         <include>org.kie.commons:kie-commons-io</include>


### PR DESCRIPTION
SWITCHYARD-325: Allow developer-defined correlationId to refer to BPM processes in addition to processInstanceId
https://issues.jboss.org/browse/SWITCHYARD-325
