### PR TITLE
SWITCHYARD-1454: Switchyard installer for EAP 6.1 Beta is causing module error

### DIFF
--- a/jboss-as7/bundle/xsl/jbossws-jboss720-server-integration_module.xsl
+++ b/jboss-as7/bundle/xsl/jbossws-jboss720-server-integration_module.xsl
@@ -36,20 +36,12 @@
     </xsl:copy>
 </xsl:template>
 
-<xsl:template match="node()[name(.)='resources']">
+<xsl:template match="node()[name(.)='resource-root'][starts-with(@path,'jboss-as-webservices-server-integration')]">
     <xsl:copy>
-        <xsl:apply-templates select="@*|node()"/>
-        <resource-root path="jbossws-jboss720-server-integration-4.2.0-SNAPSHOT.jar"/>
-        <resource-root path="jbossws-cxf-resources-4.1.3.Final-jboss711.jar"/>
+        <xsl:attribute name="path">
+            <xsl:text>jbossws-jboss720-server-integration-4.2.0-SNAPSHOT.jar</xsl:text>
+        </xsl:attribute>
     </xsl:copy>
-</xsl:template>
-
-<xsl:template match="node()[name(.)='resource-root']">
-    <xsl:text disable-output-escaping="yes">&lt;!-- </xsl:text>
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    <xsl:text disable-output-escaping="yes"> --&gt;</xsl:text>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/jboss-as7/bundle/xsl/jbossws-spi_module.xsl
+++ b/jboss-as7/bundle/xsl/jbossws-spi_module.xsl
@@ -36,19 +36,12 @@
     </xsl:copy>
 </xsl:template>
 
-<xsl:template match="node()[name(.)='resources']">
+<xsl:template match="node()[name(.)='resource-root'][starts-with(@path,'jbossws-spi')]">
     <xsl:copy>
-        <xsl:apply-templates select="@*|node()"/>
-        <resource-root path="jbossws-spi-2.1.2.Final.jar"/>
+        <xsl:attribute name="path">
+            <xsl:text>jbossws-spi-2.1.2.Final.jar</xsl:text>
+        </xsl:attribute>
     </xsl:copy>
-</xsl:template>
-
-<xsl:template match="node()[name(.)='resource-root']">
-    <xsl:text disable-output-escaping="yes">&lt;!-- </xsl:text>
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    <xsl:text disable-output-escaping="yes"> --&gt;</xsl:text>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/jboss-as7/standalone/dist/assembly.xml
+++ b/jboss-as7/standalone/dist/assembly.xml
@@ -14,6 +14,10 @@
                 <include>*.txt</include>
                 <include>standalone/**/standalone*.xml</include>
                 <include>domain/**/domain*.xml</include>
+                <include>modules/system/layers/base/org/jboss/as/webservices/main/jbossws-jboss720-server-integration-${version.jbossws.jboss720.server.integration}.jar</include>
+                <include>modules/system/layers/base/org/jboss/as/webservices/main/module.xml</include>
+                <include>modules/system/layers/base/org/jboss/ws/spi/main/jbossws-spi-${version.jbossws.spi}.jar</include>
+                <include>modules/system/layers/base/org/jboss/ws/spi/main/module.xml</include>
                 <include>modules/system/layers/soa/**</include>
                 <include>modules/layers.conf</include>
                 <include>quickstarts/**</include>


### PR DESCRIPTION
SWITCHYARD-1454: Switchyard installer for EAP 6.1 Beta is causing module error
https://issues.jboss.org/browse/SWITCHYARD-1454
