### PR TITLE
SWITCHYARD-1472 switchyard-common dependency missing on camel exchange bus

### DIFF
--- a/jboss-as7/modules/src/main/resources/switchyard/core/bus/camel/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/core/bus/camel/module.xml
@@ -36,6 +36,7 @@
         <module name="org.apache.camel.core"/>
         <module name="org.switchyard.api"/>
         <module name="org.switchyard.runtime"/>
+        <module name="org.switchyard.common"/>
         <module name="org.switchyard.common.camel"/>
     </dependencies>
 </module>


### PR DESCRIPTION
This commit may be easily appiled to 0.8 branch/tag.
