### PR TITLE
SWITCHYARD-1481 Allow camel components to be added to SY runtime.

### DIFF
--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/CommonAttributes.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/CommonAttributes.java
@@ -58,4 +58,15 @@ public interface CommonAttributes {
      * The replaceable properties.
      */
     String DOLLAR = "$";
+
+    /**
+     * The extensions element.
+     */
+    String EXTENSIONS = "extensions";
+
+    /**
+     * The extension element.
+     */
+    String EXTENSION = "extension";
+
 }

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/Element.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/Element.java
@@ -48,6 +48,16 @@ public enum Element {
     MODULE("module"),
 
     /**
+     * modules element.
+     */
+    EXTENSIONS("extensions"),
+
+    /**
+     * module element.
+     */
+    EXTENSION("extension"),
+
+    /**
      * properties element.
      */
     PROPERTIES("properties");

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtension.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtension.java
@@ -22,6 +22,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.switchyard.as7.extension.CommonAttributes.EXTENSION;
 import static org.switchyard.as7.extension.CommonAttributes.MODULE;
 
 import java.util.Locale;
@@ -67,6 +68,7 @@ public class SwitchYardExtension implements Extension {
 
     private static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
     private static final PathElement MODULE_PATH = PathElement.pathElement(MODULE);
+    private static final PathElement EXTENSION_PATH = PathElement.pathElement(EXTENSION);
     private static final String RESOURCE_NAME = SwitchYardExtension.class.getPackage().getName() + ".LocalDescriptions";
 
     /**
@@ -99,6 +101,11 @@ public class SwitchYardExtension implements Extension {
                 .addReadWriteAttribute(Attributes.IMPLCLASS, null, new ReloadRequiredWriteAttributeHandler(Attributes.IMPLCLASS))
                 .addReadWriteAttribute(Attributes.PROPERTIES, null, new ReloadRequiredWriteAttributeHandler(Attributes.PROPERTIES));
 
+        ResourceBuilder extensionsResource = ResourceBuilder.Factory.create(EXTENSION_PATH, getResourceDescriptionResolver(EXTENSION))
+                .setAddOperation(SwitchYardExtensionAdd.INSTANCE)
+                .setRemoveOperation(SwitchYardExtensionRemove.INSTANCE)
+                .addReadWriteAttribute(Attributes.IDENTIFIER, null, new ReloadRequiredWriteAttributeHandler(Attributes.IDENTIFIER));
+
         ResourceDefinition subsystemResource = ResourceBuilder.Factory.createSubsystemRoot(SUBSYSTEM_PATH, getResourceDescriptionResolver(), SwitchYardSubsystemAdd.INSTANCE, SwitchYardSubsystemRemove.INSTANCE)
                 .addReadWriteAttribute(Attributes.SOCKET_BINDING, null, new ReloadRequiredWriteAttributeHandler(Attributes.SOCKET_BINDING))
                 .addReadWriteAttribute(Attributes.PROPERTIES, null, new ReloadRequiredWriteAttributeHandler(Attributes.PROPERTIES))
@@ -110,6 +117,7 @@ public class SwitchYardExtension implements Extension {
                 .addOperation(Operations.USES_ARTIFACT, SwitchYardSubsystemUsesArtifact.INSTANCE)
                 .addOperation(Operations.SHOW_METRICS, SwitchYardSubsystemShowMetrics.INSTANCE)
                 .pushChild(modulesResource).pop()
+                .pushChild(extensionsResource).pop()
                 .build();
         subsystem.registerSubsystemModel(subsystemResource);
 

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtensionAdd.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtensionAdd.java
@@ -1,0 +1,87 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.as7.extension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.AbstractDeploymentChainStep;
+import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.as.server.deployment.Phase;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.switchyard.as7.extension.deployment.SwitchYardModuleDependencyProcessor;
+
+/**
+ * The SwitchYard subsystem's extension add update handler.
+ */
+public final class SwitchYardExtensionAdd extends AbstractAddStepHandler {
+
+    static final SwitchYardExtensionAdd INSTANCE = new SwitchYardExtensionAdd();
+
+    /**
+     * Global component names.
+     */
+    private static List<String> _extensionNames = new ArrayList<String>();
+
+    private SwitchYardExtensionAdd() {
+
+    }
+
+    /**
+     * Get the list of configured extension names.
+     * 
+     * @return the list of extensions
+     */
+    public static List<String> getExtensionNames() {
+        return _extensionNames;
+    }
+
+    @Override
+    protected void populateModel(final ModelNode operation, final Resource resource) {
+        final ModelNode model = resource.getModel();
+
+        populateModel(operation, model);
+    }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode subModel) {
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model,
+                                  ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        final String moduleId = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
+        _extensionNames.add(moduleId);
+
+        context.addStep(new AbstractDeploymentChainStep() {
+            protected void execute(DeploymentProcessorTarget processorTarget) {
+                processorTarget.addDeploymentProcessor(SwitchYardExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, 0x4002, new SwitchYardModuleDependencyProcessor(moduleId));
+            }
+        }, OperationContext.Stage.RUNTIME);
+    }
+
+}

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtensionRemove.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtensionRemove.java
@@ -1,0 +1,33 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.as7.extension;
+
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+
+/**
+ * The SwitchYard subsystem's extension add update handler.
+ */
+public final class SwitchYardExtensionRemove extends ReloadRequiredRemoveStepHandler {
+
+    static final SwitchYardExtensionRemove INSTANCE = new SwitchYardExtensionRemove();
+
+    private SwitchYardExtensionRemove() {
+    }
+
+}

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemWriter.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemWriter.java
@@ -70,6 +70,16 @@ final class SwitchYardSubsystemWriter implements XMLElementWriter<SubsystemMarsh
             }
             writer.writeEndElement();
         }
+        if (node.hasDefined(CommonAttributes.EXTENSION)) {
+            ModelNode modules = node.get(CommonAttributes.EXTENSION);
+            writer.writeStartElement(Element.EXTENSIONS.getLocalName());
+            for (Property property : modules.asPropertyList()) {
+                writer.writeStartElement(Element.EXTENSION.getLocalName());
+                writer.writeAttribute(Attribute.IDENTIFIER.getLocalName(), property.getName());
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
         writeProperties(node, writer);
         writer.writeEndElement();
     }

--- a/jboss-as7/extension/src/main/resources/org/switchyard/as7/extension/LocalDescriptions.properties
+++ b/jboss-as7/extension/src/main/resources/org/switchyard/as7/extension/LocalDescriptions.properties
@@ -16,6 +16,13 @@ switchyard.module.properties=Properties specific to the component
 switchyard.module.add=Operation creating the SwitchYard component module.
 switchyard.module.remove=Operation to remove the SwitchYard component module.
 
+# extension details
+switchyard.extensions=List of SwitchYard extensions
+switchyard.extension=A SwitchYard extension module
+switchyard.extension.identifier=Unique identifier for the extension
+switchyard.extension.add=Operation creating the SwitchYard extension module.
+switchyard.extension.remove=Operation to remove the SwitchYard extension module.
+
 # get-version operation
 switchyard.get-version=Operation returning the release version of the SwitchYard subsystem.
 switchyard.get-version.reply=The version of the SwitchYard subsystem.

--- a/jboss-as7/extension/src/main/resources/schema/jboss-switchyard.xsd
+++ b/jboss-as7/extension/src/main/resources/schema/jboss-switchyard.xsd
@@ -41,6 +41,7 @@
         <xs:all>
             <xs:element name="socket-binding" type="socketBindingsType" use="optional"/>
             <xs:element name="modules" type="modulesType" minOccurs="0"/>
+            <xs:element name="extensions" type="extensionsType" minOccurs="0"/>
             <xs:element name="properties" type="propertiesType" use="optional"/>
         </xs:all>
     </xs:complexType>
@@ -85,6 +86,21 @@
 
     <xs:complexType name="propertiesType">
         <xs:any></xs:any>
+    </xs:complexType>
+
+    <xs:complexType name="extensionsType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="module" type="extensionType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="extensionType">
+        <xs:documentation>
+        <![CDATA[
+            The SwitchYard subsystem component's module identifier.
+        ]]>
+        </xs:documentation>
+        <xs:attribute name="identifier" type="xs:string" use="required"/>
     </xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
This change introduces <extensions> element inside SwitchYard domain configuration. All modules put inside this element as <extension identifier="module-id" /> will be automatically added to all switchyard deployment units.
