### PR TITLE
SWITCHYARD-1578 NoClassDefFoundError installing Forge tools

### DIFF
--- a/installer/scripts/installer.ant.xml
+++ b/installer/scripts/installer.ant.xml
@@ -444,6 +444,7 @@
         </fileset>
 
         <fileset dir="${FORGE_PATH}/modules/org/jboss/forge/parser/java/api/main">
+	    <include name="java-parser-api-*"/>
             <include name="forge-parser-java-api-*"/>
         </fileset>
 


### PR DESCRIPTION
Add java-parser-api to the classpath to bring in the org.jboss.forge.parser.java.util.Strings class.
