### PR TITLE
SWITCHYARD-1523 installer leaves empty namespace in AS config

### DIFF
--- a/jboss-as7/bundle/xsl/domain.xsl
+++ b/jboss-as7/bundle/xsl/domain.xsl
@@ -42,7 +42,7 @@
 <xsl:template match="node()[name(.)='extensions']">
     <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
-        <extension module="org.switchyard"/>
+        <extension xmlns="urn:jboss:domain:1.4" module="org.switchyard"/>
     </xsl:copy>
 </xsl:template>
 
@@ -145,7 +145,7 @@
 
 <xsl:template match="node()[name(.)='datasources']">
     <xsl:copy>
-        <datasource jndi-name="java:jboss/datasources/jbpmDS" pool-name="jbpmDS" enabled="true" use-java-context="true">
+        <datasource xmlns="urn:jboss:domain:datasources:1.1" jndi-name="java:jboss/datasources/jbpmDS" pool-name="jbpmDS" enabled="true" use-java-context="true">
             <connection-url>jdbc:h2:mem:jbpm;DB_CLOSE_DELAY=-1</connection-url>
             <driver>h2</driver>
             <security>
@@ -179,10 +179,10 @@
 <xsl:template match="log:subsystem">
     <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
-        <logger category="org.switchyard">
+        <logger xmlns="urn:jboss:domain:logging:1.2" category="org.switchyard">
             <level name="INFO"/>
         </logger>
-        <logger category="org.apache.deltaspike.core.api.provider.BeanManagerProvider">
+        <logger xmlns="urn:jboss:domain:logging:1.2" category="org.apache.deltaspike.core.api.provider.BeanManagerProvider">
             <level name="ERROR"/>
         </logger>
     </xsl:copy>
@@ -191,7 +191,7 @@
 <xsl:template match="node()[name(.)='security-domains']">
     <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
-        <security-domain name="bpel-console" cache-type="default">
+        <security-domain xmlns="urn:jboss:domain:security:1.2" name="bpel-console" cache-type="default">
             <authentication>
                 <login-module code="UsersRoles" flag="required"/>
             </authentication>
@@ -206,7 +206,7 @@
 <xsl:template match="//as:profile[@name='ha' or @name='full-ha']/inf:subsystem">
    <xsl:copy>
    <xsl:apply-templates select="@*|node()"/>
-        <cache-container name="switchyard" default-cache="default" start="EAGER">
+        <cache-container xmlns="urn:jboss:domain:infinispan:1.4" name="switchyard" default-cache="default" start="EAGER">
            <transport lock-timeout="60000"/>
            <replicated-cache name="default" mode="SYNC" batching="true" start="EAGER">
                <locking isolation="REPEATABLE_READ"/>

--- a/jboss-as7/bundle/xsl/standalone-ha.xsl
+++ b/jboss-as7/bundle/xsl/standalone-ha.xsl
@@ -34,7 +34,7 @@
 <xsl:template match="//inf:subsystem">
     <xsl:copy>
             <xsl:apply-templates select="node()|@*"/>
-            <cache-container name="switchyard" default-cache="default" start="EAGER">
+            <cache-container xmlns="urn:jboss:domain:infinispan:1.4" name="switchyard" default-cache="default" start="EAGER">
                 <transport lock-timeout="60000"/>
                 <replicated-cache name="default" mode="SYNC" batching="true" start="EAGER">
                     <locking isolation="REPEATABLE_READ"/>

--- a/jboss-as7/bundle/xsl/standalone.xsl
+++ b/jboss-as7/bundle/xsl/standalone.xsl
@@ -40,7 +40,7 @@
 <xsl:template match="node()[name(.)='extensions']">
     <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
-        <extension module="org.switchyard"/>
+        <extension xmlns="urn:jboss:domain:1.4" module="org.switchyard"/>
     </xsl:copy>
 </xsl:template>
 
@@ -94,7 +94,7 @@
 
 <xsl:template match="node()[name(.)='datasources']">
     <xsl:copy>
-        <datasource jndi-name="java:jboss/datasources/jbpmDS" pool-name="jbpmDS" enabled="true" use-java-context="true">
+        <datasource xmlns="urn:jboss:domain:datasources:1.1" jndi-name="java:jboss/datasources/jbpmDS" pool-name="jbpmDS" enabled="true" use-java-context="true">
             <connection-url>jdbc:h2:mem:jbpm;DB_CLOSE_DELAY=-1</connection-url>
             <driver>h2</driver>
             <security>
@@ -128,10 +128,10 @@
 <xsl:template match="log:subsystem">
     <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
-        <logger category="org.switchyard">
+        <logger xmlns="urn:jboss:domain:logging:1.2" category="org.switchyard">
             <level name="INFO"/>
         </logger>
-        <logger category="org.apache.deltaspike.core.api.provider.BeanManagerProvider">
+        <logger xmlns="urn:jboss:domain:logging:1.2" category="org.apache.deltaspike.core.api.provider.BeanManagerProvider">
             <level name="ERROR"/>
         </logger>
     </xsl:copy>
@@ -140,7 +140,7 @@
 <xsl:template match="node()[name(.)='security-domains']">
     <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
-        <security-domain name="bpel-console" cache-type="default">
+        <security-domain xmlns="urn:jboss:domain:security:1.2" name="bpel-console" cache-type="default">
             <authentication>
                 <login-module code="UsersRoles" flag="required"/>
             </authentication>


### PR DESCRIPTION
Specify the namespaces in the elements we xsl:copy so that blank xmlns do not appear.
