### PR TITLE
SWITCHYARD-1595 installer copies over empty switchyard-bpel-console

### DIFF
--- a/installer/scripts/installer.ant.xml
+++ b/installer/scripts/installer.ant.xml
@@ -63,13 +63,13 @@
 
     <target name="extract-sy-tools-forge" depends="download-sy-tools" if="installForge">
         <unzip src="res/switchyard-tools.zip" dest="res/" overwrite="true">
-            <mapper type="flatten"/>
+           <globmapper from="switchyard-tools-1.0/*" to="*"/>
         </unzip>
     </target>
 
     <target name="extract-sy-tools-bpel-console" depends="download-sy-tools" if="installBPELConsole">
         <unzip src="res/switchyard-tools.zip" dest="res/" overwrite="true">
-            <mapper type="flatten"/>
+           <globmapper from="switchyard-tools-1.0/*" to="*"/>
         </unzip>
     </target>
 


### PR DESCRIPTION
Don't flatten during the unzip of switchyard-tools, otherwise contents of switchyard-bpel-console.war aren't preserved.
