### PR TITLE
SWITCHYARD-1597 Installer can't find forge tools zip

### DIFF
--- a/installer/scripts/installer.ant.xml
+++ b/installer/scripts/installer.ant.xml
@@ -328,7 +328,6 @@
     
     <target name="extract-sy-tools-forge" depends="download-sy-tools">
         <unzip src="res/switchyard-tools.zip" dest="res/" overwrite="true">
-            <mapper type="flatten"/>
         </unzip>
     </target>
     


### PR DESCRIPTION
Don't flatten the unzip contents, so that the installer can find the forge tools zip.
