### PR TITLE
SWITCHYARD-1697: Upgrade Drools/jBPM to 6.0.0.CR3

### DIFF
--- a/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/drools/main/module.xml
+++ b/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/drools/main/module.xml
@@ -30,7 +30,7 @@
         <module name="javax.persistence.api" export="true"/>
         <module name="org.antlr.antlr-runtime"/>
         <module name="org.apache.poi"/>
-        <module name="org.eclipse.jdt.core.compiler"/>
+        <module name="org.eclipse.jdt.core.compiler" export="true"/>
         <module name="org.hibernate" export="true"/>
         <module name="org.javassist"/>
         <module name="org.jboss.vfs"/>


### PR DESCRIPTION
SWITCHYARD-1697: Upgrade Drools/jBPM to 6.0.0.CR3
https://issues.jboss.org/browse/SWITCHYARD-1697
