### PR TITLE
SWITCHYARD-1729: Security context is not propagated between service calls

### DIFF
--- a/jboss-as7/bundle/xsl/standalone.xsl
+++ b/jboss-as7/bundle/xsl/standalone.xsl
@@ -48,6 +48,21 @@
     <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
         <subsystem xmlns="urn:jboss:domain:switchyard:1.0">
+            <!--
+            <security-configs>
+                <security-config identifier="org.switchyard.security.context.SecurityContext">
+                    <properties>
+                        <timeoutMillis>30000</timeoutMillis>
+                    </properties>
+                </security-config>
+                <security-config identifier="org.switchyard.security.crypto.PrivateCrypto">
+                    <properties>
+                        <sealAlgorithm>TripleDES</sealAlgorithm>
+                        <sealKeySize>168</sealKeySize>
+                    </properties>
+                </security-config>
+            </security-configs>
+            -->
             <modules>
                 <module identifier="org.switchyard.component.bean" implClass="org.switchyard.component.bean.deploy.BeanComponent"/>
                 <module identifier="org.switchyard.component.soap" implClass="org.switchyard.component.soap.deploy.SOAPComponent">

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/CommonAttributes.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/CommonAttributes.java
@@ -20,6 +20,16 @@ package org.switchyard.as7.extension;
 public interface CommonAttributes {
 
     /**
+     * The security-configs attribute.
+     */
+    String SECURITY_CONFIGS = "security-configs";
+
+    /**
+     * The security-config attribute.
+     */
+    String SECURITY_CONFIG = "security-config";
+
+    /**
      * The component modules attribute.
      */
     String MODULES = "modules";

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/Element.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/Element.java
@@ -33,6 +33,16 @@ public enum Element {
     SOCKET_BINDING("socket-binding"),
 
     /**
+     * security-configs element.
+     */
+    SECURITY_CONFIGS("security-configs"),
+
+    /**
+     * security-config element.
+     */
+    SECURITY_CONFIG("security-config"),
+
+    /**
      * modules element.
      */
     MODULES("modules"),

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtension.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardExtension.java
@@ -19,6 +19,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.switchyard.as7.extension.CommonAttributes.EXTENSION;
 import static org.switchyard.as7.extension.CommonAttributes.MODULE;
+import static org.switchyard.as7.extension.CommonAttributes.SECURITY_CONFIG;
 
 import java.util.Locale;
 
@@ -68,6 +69,7 @@ public class SwitchYardExtension implements Extension {
     public static final String NAMESPACE = "urn:jboss:domain:switchyard:1.0";
 
     private static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
+    private static final PathElement SECURITY_CONFIG_PATH = PathElement.pathElement(SECURITY_CONFIG);
     private static final PathElement MODULE_PATH = PathElement.pathElement(MODULE);
     private static final PathElement EXTENSION_PATH = PathElement.pathElement(EXTENSION);
     private static final String RESOURCE_NAME = SwitchYardExtension.class.getPackage().getName() + ".LocalDescriptions";
@@ -94,6 +96,12 @@ public class SwitchYardExtension implements Extension {
 
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0);
         subsystem.registerXMLElementWriter(SwitchYardSubsystemWriter.getInstance());
+
+        ResourceBuilder securityConfigsResource = ResourceBuilder.Factory.create(SECURITY_CONFIG_PATH, getResourceDescriptionResolver(SECURITY_CONFIG))
+                .setAddOperation(SwitchYardSecurityConfigAdd.INSTANCE)
+                .setRemoveOperation(SwitchYardSecurityConfigRemove.INSTANCE)
+                .addReadWriteAttribute(Attributes.IDENTIFIER, null, new ReloadRequiredWriteAttributeHandler(Attributes.IDENTIFIER))
+                .addReadWriteAttribute(Attributes.PROPERTIES, null, new ReloadRequiredWriteAttributeHandler(Attributes.PROPERTIES));
 
         ResourceBuilder modulesResource = ResourceBuilder.Factory.create(MODULE_PATH, getResourceDescriptionResolver(MODULE))
                 .setAddOperation(SwitchYardModuleAdd.INSTANCE)
@@ -123,6 +131,7 @@ public class SwitchYardExtension implements Extension {
                 .addOperation(Operations.STOP_GATEWAY, SwitchYardSubsystemStopGateway.INSTANCE)
                 .addOperation(Operations.START_GATEWAY, SwitchYardSubsystemStartGateway.INSTANCE)
                 .addOperation(Operations.UPDATE_THROTTLING, SwitchYardSubsystemUpdateThrottling.INSTANCE)
+                .pushChild(securityConfigsResource).pop()
                 .pushChild(modulesResource).pop()
                 .pushChild(extensionsResource).pop()
                 .build();

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSecurityConfigAdd.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSecurityConfigAdd.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.as7.extension;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceName;
+import org.switchyard.as7.extension.services.SwitchYardInjectorService;
+import org.switchyard.as7.extension.services.SwitchYardSecurityConfigService;
+import org.switchyard.as7.extension.services.SwitchYardSecurityConfigService.SecurityConfig;
+import org.switchyard.as7.extension.services.SwitchYardSystemSecurityService;
+import org.switchyard.security.system.SystemSecurity;
+
+/**
+ * The SwitchYard subsystem's module add update handler.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2013 Red Hat Inc.
+ */
+public final class SwitchYardSecurityConfigAdd extends AbstractAddStepHandler {
+
+    static final SwitchYardSecurityConfigAdd INSTANCE = new SwitchYardSecurityConfigAdd();
+
+    private SwitchYardSecurityConfigAdd() {}
+
+    @Override
+    protected void populateModel(final ModelNode operation, final Resource resource) {
+        final ModelNode model = resource.getModel();
+        populateModel(operation, model);
+    }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode subModel) {
+        if (operation.hasDefined(CommonAttributes.PROPERTIES)) {
+            subModel.get(CommonAttributes.PROPERTIES).set(operation.get(CommonAttributes.PROPERTIES));
+        }
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model,
+                                  ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        String moduleId = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
+        ServiceName serviceName = SwitchYardSecurityConfigService.SERVICE_NAME.append(moduleId);
+        SwitchYardSecurityConfigService securityConfigService = new SwitchYardSecurityConfigService(moduleId, model);
+        ServiceBuilder<SecurityConfig> securityConfigServiceBuilder = context.getServiceTarget().addService(serviceName, securityConfigService);
+        securityConfigServiceBuilder.addDependency(SwitchYardSystemSecurityService.SERVICE_NAME, SystemSecurity.class, securityConfigService.getSystemSecurity());
+        securityConfigServiceBuilder.addDependency(SwitchYardInjectorService.SERVICE_NAME, Map.class, securityConfigService.getInjectedValues());
+        securityConfigServiceBuilder.setInitialMode(Mode.ACTIVE);
+        newControllers.add(securityConfigServiceBuilder.install());
+    }
+
+}

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSecurityConfigRemove.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSecurityConfigRemove.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.as7.extension;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * The SwitchYard subsystem's security-config add update handler.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2013 Red Hat Inc.
+ */
+public final class SwitchYardSecurityConfigRemove extends ReloadRequiredRemoveStepHandler {
+
+    static final SwitchYardSecurityConfigRemove INSTANCE = new SwitchYardSecurityConfigRemove();
+
+    private SwitchYardSecurityConfigRemove() {
+
+    }
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performRuntime(context, operation, model);
+    }
+
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+        super.recoverServices(context, operation, model);
+    }
+
+}

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemWriter.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/SwitchYardSubsystemWriter.java
@@ -50,6 +50,18 @@ final class SwitchYardSubsystemWriter implements XMLElementWriter<SubsystemMarsh
             writer.writeEmptyElement(Element.SOCKET_BINDING.getLocalName());
             writer.writeAttribute(Attribute.NAMES.getLocalName(), socketNames.asString());
         }
+        if (node.hasDefined(CommonAttributes.SECURITY_CONFIG)) {
+            ModelNode modules = node.get(CommonAttributes.SECURITY_CONFIG);
+            writer.writeStartElement(Element.SECURITY_CONFIGS.getLocalName());
+            for (Property property : modules.asPropertyList()) {
+                writer.writeStartElement(Element.SECURITY_CONFIG.getLocalName());
+                writer.writeAttribute(Attribute.IDENTIFIER.getLocalName(), property.getName());
+                ModelNode entry = property.getValue();
+                writeProperties(entry, writer);
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
         if (node.hasDefined(CommonAttributes.MODULE)) {
             ModelNode modules = node.get(CommonAttributes.MODULE);
             writer.writeStartElement(Element.MODULES.getLocalName());

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/services/SwitchYardSecurityConfigService.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/services/SwitchYardSecurityConfigService.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.as7.extension.services;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.switchyard.as7.extension.CommonAttributes;
+import org.switchyard.as7.extension.services.SwitchYardSecurityConfigService.SecurityConfig;
+import org.switchyard.common.lang.Strings;
+import org.switchyard.security.context.SecurityContext;
+import org.switchyard.security.crypto.PrivateCrypto;
+import org.switchyard.security.crypto.PublicCrypto;
+import org.switchyard.security.system.DefaultSystemSecurity;
+import org.switchyard.security.system.SystemSecurity;
+
+/**
+ * The SwitchYard SecurityConfig service.
+ * 
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2013 Red Hat Inc.
+ */
+public class SwitchYardSecurityConfigService implements Service<SecurityConfig> {
+
+    /**
+     * Represents a SwitchYard SecurityConfig initializer service name.
+     */
+    public static final ServiceName SERVICE_NAME = ServiceName.of("SwitchYardSecurityConfigService");
+
+    private final InjectedValue<SystemSecurity> _systemSecurity = new InjectedValue<SystemSecurity>();
+    private final InjectedValue<Map> _injectedValues = new InjectedValue<Map>();
+
+    private String _moduleId;
+    private ModelNode _model;
+    private SecurityConfig _securityConfig;
+
+    /**
+     * Constructs a SwitchYard SecurityConfig service.
+     * 
+     * @param moduleId the module identifier
+     * @param model the Module's model operation
+     */
+    public SwitchYardSecurityConfigService(String moduleId, ModelNode model) {
+        _moduleId = moduleId;
+        _model = model;
+    }
+
+    @Override
+    public SecurityConfig getValue() throws IllegalStateException,
+            IllegalArgumentException {
+        return _securityConfig;
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        ModelNode propertiesModel = _model.hasDefined(CommonAttributes.PROPERTIES) ? _model.get(CommonAttributes.PROPERTIES) : null;
+        Properties securityProps = toProperties(propertiesModel);
+        _securityConfig = new SecurityConfig(securityProps);
+        DefaultSystemSecurity systemSecurity = (DefaultSystemSecurity)getSystemSecurity().getValue();
+        if (SecurityContext.class.getName().equals(_moduleId)) {
+            String timeoutMillis = Strings.trimToNull(securityProps.getProperty("timeoutMillis"));
+            if (timeoutMillis != null) {
+                systemSecurity.setSecurityContextTimeoutMillis(Long.valueOf(timeoutMillis));
+            }
+        }
+        if (PrivateCrypto.class.getName().equals(_moduleId)) {
+            systemSecurity.setPrivateCrypto(new PrivateCrypto(securityProps));
+        }
+        if (PublicCrypto.class.getName().equals(_moduleId)) {
+            systemSecurity.setPublicCrypto(new PublicCrypto(securityProps));
+        }
+    }
+
+    private Properties toProperties(ModelNode propertiesModel) {
+        Properties properties = new Properties();
+        if (propertiesModel != null) {
+            Set<String> names = propertiesModel.keys();
+            if (names != null) {
+                for (String name : names) {
+                    String value = propertiesModel.get(name).asString();
+                    if (value.startsWith(CommonAttributes.DOLLAR)) {
+                        String key = value.substring(1);
+                        String injectedValue = (String)_injectedValues.getValue().get(key);
+                        if (injectedValue != null) {
+                            properties.setProperty(name, injectedValue);
+                        }
+                    } else {
+                        properties.setProperty(name, value);
+                    }
+                }
+            }
+        }
+        return properties;
+    }
+
+    @Override
+    public void stop(StopContext context) {
+    }
+
+    /**
+     * SystemSecurity injection point.
+     * 
+     * @return injected SystemSecurity
+     */
+    public InjectedValue<SystemSecurity> getSystemSecurity() {
+        return _systemSecurity;
+    }
+
+    /**
+     * Injection point for injectValues.
+     * 
+     * @return a map of injected values
+     */
+    public InjectedValue<Map> getInjectedValues() {
+        return _injectedValues;
+    }
+
+    /**
+     * SecurityConfig.
+     */
+    public static final class SecurityConfig {
+        private final Properties _properties;
+        /**
+         * Creates a new SecurityConfig with the specified properties.
+         * @param properties the properties
+         */
+        public SecurityConfig(Properties properties) {
+            _properties = properties;
+        }
+        /**
+         * Gets the properties.
+         * @return the properties
+         */
+        public Properties getProperties() {
+            return _properties;
+        }
+    }
+
+}

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/services/SwitchYardServiceDomainManagerService.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/services/SwitchYardServiceDomainManagerService.java
@@ -22,6 +22,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.switchyard.deploy.ServiceDomainManager;
+import org.switchyard.security.system.SystemSecurity;
 
 /**
  * ServiceDomainManager Service for AS7 deployments.
@@ -37,21 +38,30 @@ public class SwitchYardServiceDomainManagerService implements Service<ServiceDom
 
     private ServiceDomainManager _domainManager;
 
+    private final InjectedValue<SystemSecurity> _systemSecurity = new InjectedValue<SystemSecurity>();
     private final InjectedValue<Cache> _cache = new InjectedValue<Cache>();
 
     @Override
     public void start(StartContext startContext) throws StartException {
-        _domainManager = new ServiceDomainManager();
+        _domainManager = new ServiceDomainManager(getSystemSecurity().getValue());
     }
 
     @Override
     public void stop(StopContext stopContext) {
-        //endpoint.stop();    
     }
 
     @Override
     public ServiceDomainManager getValue() throws IllegalStateException, IllegalArgumentException {
         return _domainManager;
+    }
+
+    /**
+     * SystemSecurity injection point.
+     * 
+     * @return injected SystemSecurity
+     */
+    public InjectedValue<SystemSecurity> getSystemSecurity() {
+        return _systemSecurity;
     }
 
     /**

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/services/SwitchYardSystemSecurityService.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/services/SwitchYardSystemSecurityService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.switchyard.as7.extension.services;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.switchyard.security.system.DefaultSystemSecurity;
+import org.switchyard.security.system.SystemSecurity;
+
+/**
+ * SystemSecurity Service for AS7 deployments.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2013 Red Hat Inc.
+ */
+public class SwitchYardSystemSecurityService implements Service<SystemSecurity> {
+
+    /**
+     * The name used to resolve the SystemSecurity.
+     */
+    public final static ServiceName SERVICE_NAME = ServiceName.of(SwitchYardSystemSecurityService.class.getSimpleName());
+
+    private SystemSecurity _systemSecurity = null;
+
+    @Override
+    public void start(StartContext startContext) throws StartException {
+        _systemSecurity = new DefaultSystemSecurity();
+    }
+
+    @Override
+    public void stop(StopContext stopContext) {
+        _systemSecurity = null;
+    }
+
+    @Override
+    public SystemSecurity getValue() throws IllegalStateException, IllegalArgumentException {
+        return _systemSecurity;
+    }
+
+}

--- a/jboss-as7/extension/src/main/resources/org/switchyard/as7/extension/LocalDescriptions.properties
+++ b/jboss-as7/extension/src/main/resources/org/switchyard/as7/extension/LocalDescriptions.properties
@@ -7,6 +7,14 @@ switchyard.properties=Global properties shared across SwitchYard subsystem
 switchyard.deployment=Runtime resources exposed by SwitchYard components in the deployment.
 switchyard.deployment.application=Details of SwitchYard application in a deployment.
 
+# security-config details
+switchyard.security-configs=List of SwitchYard security configs
+switchyard.security-config=A SwitchYard security config
+switchyard.security-config.identifier=Unique identifier for the security config
+switchyard.security-config.properties=Properties specific to the security config
+switchyard.security-config.add=Operation creating the SwitchYard security config.
+switchyard.security-config.remove=Operation to remove the SwitchYard security config.
+
 # module details
 switchyard.modules=List of SwitchYard components
 switchyard.module=A SwitchYard component module

--- a/jboss-as7/pom.xml
+++ b/jboss-as7/pom.xml
@@ -260,6 +260,11 @@
         </dependency>
         <dependency>
             <groupId>org.switchyard.quickstarts.demos</groupId>
+            <artifactId>switchyard-quickstart-demo-policy-security-basic-propagate</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard.quickstarts.demos</groupId>
             <artifactId>switchyard-quickstart-demo-policy-security-cert</artifactId>
             <scope>test</scope>
         </dependency>

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/demo/PolicySecurityBasicPropagateDemoQuickstartTest.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/demo/PolicySecurityBasicPropagateDemoQuickstartTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.test.quickstarts.demo;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.test.ArquillianUtil;
+
+/**
+ * The policy-security-basic-propagate demo quickstart test.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2013 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+public class PolicySecurityBasicPropagateDemoQuickstartTest {
+
+    @Deployment(testable = false)
+    public static JavaArchive createDeployment() {
+        return ArquillianUtil.createJarDemoDeployment("switchyard-quickstart-demo-policy-security-basic-propagate");
+    }
+
+    @Test
+    public void test() throws Exception {
+        Assert.assertTrue(true);
+    }
+
+}


### PR DESCRIPTION
SWITCHYARD-1729: Security context is not propagated between service calls
https://issues.jboss.org/browse/SWITCHYARD-1729
