### PR TITLE
SWITCHYARD-1778: Upgrade KIE/Drools/jBPM from 6.0.0.CR3 to 6.0.0.CR5

### DIFF
--- a/jboss-as7/kiedroolsjbpm/pom.xml
+++ b/jboss-as7/kiedroolsjbpm/pom.xml
@@ -186,10 +186,6 @@
         </dependency>
         <dependency>
             <groupId>org.jbpm</groupId>
-            <artifactId>jbpm-form-services</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jbpm</groupId>
             <artifactId>jbpm-human-task-core</artifactId>
         </dependency>
         <dependency>

--- a/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/assembly-component.xml
+++ b/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/assembly-component.xml
@@ -34,7 +34,6 @@
                 <include>org.jbpm:jbpm-bpmn2</include>
                 <include>org.jbpm:jbpm-flow</include>
                 <include>org.jbpm:jbpm-flow-builder</include>
-                <include>org.jbpm:jbpm-form-services</include>
                 <include>org.jbpm:jbpm-human-task-core</include>
                 <include>org.jbpm:jbpm-human-task-workitems</include>
                 <include>org.jbpm:jbpm-kie-services</include>

--- a/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/module.xml
+++ b/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/module.xml
@@ -18,7 +18,6 @@
         <resource-root path="jbpm-bpmn2-${version.jbpm}.jar"/>
         <resource-root path="jbpm-flow-${version.jbpm}.jar"/>
         <resource-root path="jbpm-flow-builder-${version.jbpm}.jar"/>
-        <resource-root path="jbpm-form-services-${version.jbpm}.jar"/>
         <resource-root path="jbpm-human-task-core-${version.jbpm}.jar"/>
         <resource-root path="jbpm-human-task-workitems-${version.jbpm}.jar"/>
         <resource-root path="jbpm-kie-services-${version.jbpm}.jar"/>


### PR DESCRIPTION
SWITCHYARD-1778: Upgrade KIE/Drools/jBPM from 6.0.0.CR3 to 6.0.0.CR5
https://issues.jboss.org/browse/SWITCHYARD-1778
