### PR TITLE
SWITCHYARD-1819: Camel FTPS binding cannot be used because of java.lang.NoClassDefFoundError: javax/net/ssl/SSLException

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/camel/ftp/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/camel/ftp/module.xml
@@ -19,6 +19,7 @@
     </resources>
 
     <dependencies>
+        <module name="javax.api"/>
         <module name="org.slf4j"/>
         <module name="org.apache.commons.net"/>
         <module name="com.jcraft.jsch"/>


### PR DESCRIPTION
SWITCHYARD-1819: Camel FTPS binding cannot be used because of java.lang.NoClassDefFoundError: javax/net/ssl/SSLException
https://issues.jboss.org/browse/SWITCHYARD-1819
