### PR TITLE
SWITCHYARD-1809 Change org.apache.log4j dependency to org.jboss.logging

### DIFF
--- a/tools/forge/src/main/resources/dependencies/module.xml
+++ b/tools/forge/src/main/resources/dependencies/module.xml
@@ -23,8 +23,8 @@
     <module name="javax.xml.bind.api"/>
     <module name="javax.api"/>
     <module name="org.jboss.forge.shell.api"/>
+    <module name="org.jboss.logging"/>
     <module name="org.slf4j"/>
-    <module name="org.apache.log4j"/>
   </dependencies>
   
 </module>


### PR DESCRIPTION
Change dependency on org.apache.log4j to org.jboss.logging.    
