### PR TITLE
SWITCHYARD-1789 JCAActivator should wait for the HornetQ RAR deployment

### DIFF
--- a/jboss-as7/extension/pom.xml
+++ b/jboss-as7/extension/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>switchyard-component-soap</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.switchyard.components</groupId>
+            <artifactId>switchyard-component-jca</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
         </dependency>

--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/deployment/SwitchYardDeploymentProcessor.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/deployment/SwitchYardDeploymentProcessor.java
@@ -13,10 +13,15 @@
  */
 package org.switchyard.as7.extension.deployment;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jboss.as.clustering.infinispan.subsystem.CacheService;
+import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.naming.context.NamespaceContextSelector;
 import org.jboss.as.naming.deployment.JndiNamingDependencyProcessor;
+import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -25,6 +30,7 @@ import org.jboss.as.weld.WeldDeploymentMarker;
 import org.jboss.as.weld.WeldStartService;
 import org.jboss.as.weld.services.BeanManagerService;
 import org.jboss.logging.Logger;
+import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceBuilder.DependencyType;
 import org.jboss.msc.service.ServiceController.Mode;
@@ -36,6 +42,14 @@ import org.switchyard.as7.extension.SwitchYardModuleAdd;
 import org.switchyard.as7.extension.services.SwitchYardComponentService;
 import org.switchyard.as7.extension.services.SwitchYardService;
 import org.switchyard.as7.extension.services.SwitchYardServiceDomainManagerService;
+import org.switchyard.component.jca.config.model.InboundConnectionModel;
+import org.switchyard.component.jca.config.model.JCABindingModel;
+import org.switchyard.component.jca.config.model.OutboundConnectionModel;
+import org.switchyard.component.jca.config.model.ResourceAdapterModel;
+import org.switchyard.config.model.composite.BindingModel;
+import org.switchyard.config.model.composite.CompositeModel;
+import org.switchyard.config.model.composite.CompositeReferenceModel;
+import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.deploy.Component;
 import org.switchyard.deploy.ServiceDomainManager;
 
@@ -95,10 +109,63 @@ public class SwitchYardDeploymentProcessor implements DeploymentUnitProcessor {
             }
         }
         
+        // Collect all the resource adapters referenced from SwitchYard configuration
+        Set<String> resourceAdapters = new HashSet<String>();
+        ClassLoader origCl = Thread.currentThread().getContextClassLoader();
+        try {
+            final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+            Thread.currentThread().setContextClassLoader(module.getClassLoader());
+            CompositeModel composite = metaData.getSwitchYardModel().getComposite();
+            for (CompositeServiceModel service : composite.getServices()) {
+                for (BindingModel binding : service.getBindings()) {
+                    if (binding instanceof JCABindingModel) {
+                        JCABindingModel jcabinding = JCABindingModel.class.cast(binding);
+                        InboundConnectionModel ic = jcabinding.getInboundConnection();
+                        if (ic != null) {
+                            ResourceAdapterModel ra = ic.getResourceAdapter();
+                            if (ra != null && ra.getName() != null && !ra.getName().isEmpty()) {
+                                resourceAdapters.add(ra.getName());
+                            }
+                        }
+                    }
+                }
+            }
+            for (CompositeReferenceModel reference : composite.getReferences()) {
+                for (BindingModel binding : reference.getBindings()) {
+                    if (binding instanceof JCABindingModel) {
+                        JCABindingModel jcabinding = JCABindingModel.class.cast(binding);
+                        OutboundConnectionModel oc = jcabinding.getOutboundConnection();
+                        if (oc != null) {
+                            ResourceAdapterModel ra = oc.getResourceAdapter();
+                            if (ra != null && ra.getName() != null && !ra.getName().isEmpty()) {
+                                resourceAdapters.add(ra.getName());
+                            }
+                        }
+                    }
+                }
+            }
+        } finally {
+                Thread.currentThread().setContextClassLoader(origCl);
+        }
+        for (String raName : resourceAdapters) {
+            switchyardServiceBuilder.addDependency(ConnectorServices.RESOURCE_ADAPTER_SERVICE_PREFIX
+                                                                    .append(stripDotRarSuffix(raName)));
+        }
+
         switchyardServiceBuilder.addDependency(DependencyType.OPTIONAL, CacheService.getServiceName("cluster", null));
 
         switchyardServiceBuilder.setInitialMode(Mode.ACTIVE);
         switchyardServiceBuilder.install();
+    }
+
+    private String stripDotRarSuffix(final String raName) {
+        if (raName == null) {
+            return null;
+        }
+        if (raName.endsWith(".rar")) {
+            return raName.substring(0, raName.indexOf(".rar"));
+        }
+        return raName;
     }
 
     @Override

--- a/jboss-as7/modules/src/main/resources/switchyard/core/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/core/module.xml
@@ -57,6 +57,7 @@
         <module name="org.switchyard.component.resteasy"/>
         <module name="org.switchyard.component.sca"/>
         <module name="org.switchyard.component.soap"/>
+        <module name="org.switchyard.component.jca"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Now all the resource adapters referenced from JCA binding is added as a dependency

Hi @kcbabo

Are you OK to parsing JCA binding model in the SwitchYardDeploymentProcessor like this so the user doesn't have to configure RAR name other than switchyard.xml?

The another option is adding "resource-adapter-ref" to the switchyard subsystem configuration, and SwitchYardDeploymentProcessor adds the dependency only if that parameter is configured. We can add "hornetq-ra" as a default parameter into _-full-_.xml configuration.

Thanks,
Tomo
