### PR TITLE
SWITCHYARD-1832: SY Quickstart rules-interview-container gives NPE when tested through SOAPUI

### DIFF
--- a/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/RulesInterviewContainerQuickstartTest.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/RulesInterviewContainerQuickstartTest.java
@@ -16,7 +16,6 @@ package org.switchyard.test.quickstarts;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.test.ArquillianUtil;
@@ -33,13 +32,11 @@ public class RulesInterviewContainerQuickstartTest {
     }
 
     @Test
-    @Ignore("TODO: This test works without Arquillian; needs further investigation.")
     public void testVerifyPass() throws Exception {
         RulesInterviewQuickstartTest.doTestVerify("rules-interview-container", true);
     }
 
     @Test
-    @Ignore("TODO: This test works without Arquillian; needs further investigation.")
     public void testVerifyFail() throws Exception {
         RulesInterviewQuickstartTest.doTestVerify("rules-interview-container", false);
     }


### PR DESCRIPTION
SWITCHYARD-1832: SY Quickstart rules-interview-container gives NPE when tested through SOAPUI
https://issues.jboss.org/browse/SWITCHYARD-1832
