### PR TITLE
SWITCHYARD-1909 camel-netty module missing dependency on org.apache.comm...

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/camel/netty/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/camel/netty/module.xml
@@ -23,5 +23,6 @@
         <module name="javax.api"/>
         <module name="org.jboss.netty"/>
         <module name="org.apache.camel.core"/>
+        <module name="org.apache.commons.pool"/>
     </dependencies>
 </module>


### PR DESCRIPTION
...ons.pool.PoolableObjectFactory

tested with the reproducer attached here - https://bugzilla.redhat.com/show_bug.cgi?id=1039891
