### PR TITLE
SWITCHYARD-1935: Upgrade KIE/Drools/jBPM from 6.0.0.Final to 6.0.1.Final

### DIFF
--- a/jboss-as7/kiedroolsjbpm/pom.xml
+++ b/jboss-as7/kiedroolsjbpm/pom.xml
@@ -56,13 +56,25 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.jbpm</groupId>
-                                    <artifactId>jbpm-persistence-jpa</artifactId>
+                                    <artifactId>jbpm-human-task-audit</artifactId>
                                     <version>${version.jbpm}</version>
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.jbpm</groupId>
                                     <artifactId>jbpm-human-task-core</artifactId>
+                                    <version>${version.jbpm}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.jbpm</groupId>
+                                    <artifactId>jbpm-kie-services</artifactId>
+                                    <version>${version.jbpm}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.jbpm</groupId>
+                                    <artifactId>jbpm-persistence-jpa</artifactId>
                                     <version>${version.jbpm}</version>
                                     <type>jar</type>
                                 </artifactItem>
@@ -184,6 +196,10 @@
         <dependency>
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-flow-builder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-human-task-audit</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jbpm</groupId>

--- a/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/assembly-component.xml
+++ b/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/assembly-component.xml
@@ -34,6 +34,7 @@
                 <include>org.jbpm:jbpm-bpmn2</include>
                 <include>org.jbpm:jbpm-flow</include>
                 <include>org.jbpm:jbpm-flow-builder</include>
+                <include>org.jbpm:jbpm-human-task-audit</include>
                 <include>org.jbpm:jbpm-human-task-core</include>
                 <include>org.jbpm:jbpm-human-task-workitems</include>
                 <include>org.jbpm:jbpm-kie-services</include>

--- a/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/module.xml
+++ b/jboss-as7/kiedroolsjbpm/src/main/resources/modules/system/layers/soa/org/jbpm/main/module.xml
@@ -18,6 +18,7 @@
         <resource-root path="jbpm-bpmn2-${version.jbpm}.jar"/>
         <resource-root path="jbpm-flow-${version.jbpm}.jar"/>
         <resource-root path="jbpm-flow-builder-${version.jbpm}.jar"/>
+        <resource-root path="jbpm-human-task-audit-${version.jbpm}.jar"/>
         <resource-root path="jbpm-human-task-core-${version.jbpm}.jar"/>
         <resource-root path="jbpm-human-task-workitems-${version.jbpm}.jar"/>
         <resource-root path="jbpm-kie-services-${version.jbpm}.jar"/>

--- a/jboss-as7/modules/src/main/resources/switchyard/components/bpm/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/bpm/resources/module.xml
@@ -20,7 +20,14 @@
         <module name="com.google.protobuf"/>
         <module name="org.jboss.logging"/>
         <module name="org.drools" export="true"/>
-        <module name="org.jbpm" export="true"/>
+        <module name="org.jbpm" export="true">
+            <imports>
+                <include path="META-INF/services"/>
+            </imports>
+            <exports>
+                <include path="META-INF/services"/>
+            </exports>
+        </module>
         <module name="org.kie" export="true"/>
         <module name="org.switchyard.api"/>
         <module name="org.switchyard.common"/>


### PR DESCRIPTION
SWITCHYARD-1935: Upgrade KIE/Drools/jBPM from 6.0.0.Final to 6.0.1.Final
https://issues.jboss.org/browse/SWITCHYARD-1935
