### PR TITLE
SWITCHYARD-2158 Fix Wildfly Atom/RSS component mismatch in xsl

### DIFF
--- a/jboss-as7/wildfly/bundle/xsl/domain.xsl
+++ b/jboss-as7/wildfly/bundle/xsl/domain.xsl
@@ -71,7 +71,7 @@
                 <module identifier="org.switchyard.component.camel.mail" implClass="org.switchyard.component.camel.mail.deploy.CamelMailComponent"/>
                 <module identifier="org.switchyard.component.camel.netty" implClass="org.switchyard.component.camel.netty.deploy.CamelNettyComponent"/>
                 <module identifier="org.switchyard.component.camel.quartz" implClass="org.switchyard.component.camel.quartz.deploy.CamelQuartzComponent"/>
-                <module identifier="org.switchyard.component.camel.rss" implClass="org.switchyard.component.camel.atom.deploy.CamelRSSComponent"/>
+                <module identifier="org.switchyard.component.camel.rss" implClass="org.switchyard.component.camel.rss.deploy.CamelRSSComponent"/>
                 <module identifier="org.switchyard.component.camel.sql" implClass="org.switchyard.component.camel.sql.deploy.CamelSqlComponent"/>
                 <module identifier="org.switchyard.component.rules" implClass="org.switchyard.component.rules.deploy.RulesComponent"/>
                 <module identifier="org.switchyard.component.bpm" implClass="org.switchyard.component.bpm.deploy.BPMComponent"/>

--- a/jboss-as7/wildfly/bundle/xsl/standalone.xsl
+++ b/jboss-as7/wildfly/bundle/xsl/standalone.xsl
@@ -80,7 +80,7 @@
                 <module identifier="org.switchyard.component.camel.mail" implClass="org.switchyard.component.camel.mail.deploy.CamelMailComponent"/>
                 <module identifier="org.switchyard.component.camel.netty" implClass="org.switchyard.component.camel.netty.deploy.CamelNettyComponent"/>
                 <module identifier="org.switchyard.component.camel.quartz" implClass="org.switchyard.component.camel.quartz.deploy.CamelQuartzComponent"/>
-                <module identifier="org.switchyard.component.camel.rss" implClass="org.switchyard.component.camel.atom.deploy.CamelRSSComponent"/>
+                <module identifier="org.switchyard.component.camel.rss" implClass="org.switchyard.component.camel.rss.deploy.CamelRSSComponent"/>
                 <module identifier="org.switchyard.component.camel.sql" implClass="org.switchyard.component.camel.sql.deploy.CamelSqlComponent"/>
                 <module identifier="org.switchyard.component.rules" implClass="org.switchyard.component.rules.deploy.RulesComponent"/>
                 <module identifier="org.switchyard.component.bpm" implClass="org.switchyard.component.bpm.deploy.BPMComponent"/>

--- a/jboss-as7/wildfly/dist/src/test/resources/standalone-test.xml
+++ b/jboss-as7/wildfly/dist/src/test/resources/standalone-test.xml
@@ -611,6 +611,9 @@
                 <module identifier="org.switchyard.component.resteasy" implClass="org.switchyard.component.resteasy.deploy.RESTEasyComponent"/>
             </modules>
             <extensions>
+                <extension identifier="org.apache.camel.bindy"/>
+                <extension identifier="org.apache.camel.hl7"/>
+                <extension identifier="org.apache.camel.mina2"/>
                 <extension identifier="org.apache.camel.mvel"/>
                 <extension identifier="org.apache.camel.ognl"/>
                 <extension identifier="org.apache.camel.jaxb"/>


### PR DESCRIPTION
Fix Wildfly Atom/RSS component mismatch in xsl.
Also add missing Camel extensions into Wildfly standalone-test.xml.
