### PR TITLE
SWITCHYARD-2175 Atom bound service throws errors

### DIFF
--- a/jboss-as7/modules/src/main/resources/switchyard/components/camel/atom/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/camel/atom/resources/module.xml
@@ -51,5 +51,6 @@
                 <include path="META-INF/services" />
             </exports>
         </module>
+        <module name="org.apache.abdera.abdera-parser" export="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Add a default transformer from Abdera FOMEntry->String for the Atom binding.    Also, add abdera-parser as a dependency for the Atom component to prevent exceptions.
