### PR TITLE
SWITCHYARD-2187 Add org.apache.mina:main to soa module layer

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/apache/mina/assembly-component.xml
+++ b/jboss-as7/modules/src/main/resources/external/apache/mina/assembly-component.xml
@@ -18,13 +18,13 @@
   <files>
     <file>
       <source>src/main/resources/external/apache/mina/module.xml</source>
-      <outputDirectory>/modules/system/layers/soa/org/apache/mina/${version.mina2}</outputDirectory>
+      <outputDirectory>/modules/system/layers/soa/org/apache/mina/main</outputDirectory>
       <filtered>true</filtered>
     </file>
   </files>
   <dependencySets>
     <dependencySet>
-      <outputDirectory>/modules/system/layers/soa/org/apache/mina/${artifact.baseVersion}</outputDirectory>
+      <outputDirectory>/modules/system/layers/soa/org/apache/mina/main</outputDirectory>
       <includes>
         <include>org.apache.mina:mina-core</include>
       </includes>

--- a/jboss-as7/modules/src/main/resources/external/apache/mina/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/apache/mina/module.xml
@@ -12,7 +12,7 @@
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
-<module xmlns="urn:jboss:module:1.0" name="org.apache.mina" slot="${version.mina2}">
+<module xmlns="urn:jboss:module:1.0" name="org.apache.mina">
 
     <resources>
         <resource-root path="mina-core-${version.mina2}.jar"/>


### PR DESCRIPTION
Add org.apache.mina:main to soa module layer to replace the org.apache.mina:main that disappeared from the bpms modules.
