### PR TITLE
SWITCHYARD-2230: Rules component now requires javax.api dependency for AS7 module

### DIFF
--- a/jboss-as7/modules/src/main/resources/switchyard/components/rules/resources/module.xml
+++ b/jboss-as7/modules/src/main/resources/switchyard/components/rules/resources/module.xml
@@ -17,6 +17,7 @@
         <resource-root path="switchyard-component-rules-${project.version}.jar"/>
     </resources>
     <dependencies>
+        <module name="javax.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.drools" export="true"/>
         <module name="org.kie" export="true"/>


### PR DESCRIPTION
SWITCHYARD-2230: Rules component now requires javax.api dependency for AS7 module
https://issues.jboss.org/browse/SWITCHYARD-2230
