### PR TITLE
SWITCHYARD-2167 switchyard.xml file is not included in camel-soap-proxy.jar

### DIFF
--- a/karaf/features/src/main/resources/features.xml
+++ b/karaf/features/src/main/resources/features.xml
@@ -546,11 +546,14 @@
     </feature>
 
     <!-- Requires SOAP binding -->
-    <!--feature name="switchyard-quickstart-camel-soap-proxy" version="${project.version}" resolver="(obr)">
+    <feature name="switchyard-quickstart-camel-soap-proxy" version="${project.version}" resolver="(obr)">
+        <feature>cxf</feature>
+        <feature version="${project.version}">switchyard-bean</feature>
         <feature version="${project.version}">switchyard-camel</feature>
         <feature version="${project.version}">switchyard-soap</feature>
-        <bundle>mvn:org.switchyard.quickstarts/switchyard-camel-soap-proxy/${project.version}</bundle>
-    </feature-->
+        <bundle>mvn:org.switchyard.quickstarts/switchyard-camel-soap-proxy-reverse/${project.version}</bundle>
+	<bundle>mvn:org.switchyard.quickstarts/switchyard-camel-soap-karaf-proxy/${project.version}</bundle>
+    </feature>
 
     <feature name="switchyard-quickstart-camel-sql-binding" version="${project.version}" resolver="(obr)">
         <feature>jndi</feature>


### PR DESCRIPTION
Add feature for camel-soap-proxy quickstart.
