### PR TITLE
SWITCHYARD-2262 transaction bridging should not be attempted in Karaf

### DIFF
--- a/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/cluster/RemoteEndpointListener.java
+++ b/jboss-as7/extension/src/main/java/org/switchyard/as7/extension/cluster/RemoteEndpointListener.java
@@ -55,6 +55,7 @@ public class RemoteEndpointListener implements RemoteEndpointPublisher {
     private String _contextName;
     private StandardContext _serverContext;
     private Map<QName, ServiceDomain> _services = new ConcurrentHashMap<QName, ServiceDomain>();
+    private boolean _disableRemoteTransaction = false;
     
     private boolean _started;
 
@@ -197,6 +198,17 @@ public class RemoteEndpointListener implements RemoteEndpointPublisher {
     @Override
     public ServiceDomain getDomain(QName serviceName) {
         return _services.get(serviceName);
+    }
+
+    @Override
+    public RemoteEndpointPublisher setDisableRemoteTransaction(boolean disable) {
+        _disableRemoteTransaction = disable;
+        return this;
+    }
+
+    @Override
+    public boolean isDisableRemoteTransaction() {
+        return _disableRemoteTransaction;
     }
 
 }

--- a/jboss-as7/wildfly/extension/src/main/java/org/switchyard/as7/extension/cluster/RemoteEndpointListener.java
+++ b/jboss-as7/wildfly/extension/src/main/java/org/switchyard/as7/extension/cluster/RemoteEndpointListener.java
@@ -48,6 +48,7 @@ public class RemoteEndpointListener implements RemoteEndpointPublisher {
     private String _contextName;
     private WebDeploymentController _handle;
     private Map<QName, ServiceDomain> _services = new ConcurrentHashMap<QName, ServiceDomain>();
+    private boolean _disableRemoteTransaction = false;
     
     private boolean _started;
 
@@ -155,6 +156,17 @@ public class RemoteEndpointListener implements RemoteEndpointPublisher {
     @Override
     public ServiceDomain getDomain(QName serviceName) {
         return _services.get(serviceName);
+    }
+
+    @Override
+    public RemoteEndpointPublisher setDisableRemoteTransaction(boolean disable) {
+        _disableRemoteTransaction = disable;
+        return this;
+    }
+
+    @Override
+    public boolean isDisableRemoteTransaction() {
+        return _disableRemoteTransaction;
     }
 
 }

--- a/karaf/deploy/src/main/java/org/switchyard/deploy/osgi/internal/sca/OsgiHttpEndpointPublisher.java
+++ b/karaf/deploy/src/main/java/org/switchyard/deploy/osgi/internal/sca/OsgiHttpEndpointPublisher.java
@@ -37,6 +37,7 @@ public class OsgiHttpEndpointPublisher implements RemoteEndpointPublisher {
     private String _contextName;
     private String _address;
     private int _port;
+    private boolean _disableRemoteTransaction = false;
     private Map<QName, ServiceDomain> _services = new ConcurrentHashMap<QName, ServiceDomain>();
 
     private static Logger _log = Logger.getLogger(OsgiHttpEndpointPublisher.class);
@@ -96,6 +97,17 @@ public class OsgiHttpEndpointPublisher implements RemoteEndpointPublisher {
         return _address;
     }
     
+    @Override
+    public RemoteEndpointPublisher setDisableRemoteTransaction(boolean disable) {
+        _disableRemoteTransaction = disable;
+        return this;
+    }
+
+    @Override
+    public boolean isDisableRemoteTransaction() {
+        return _disableRemoteTransaction;
+    }
+
     /**
      * Set the endpoint URL for the remote listener.  Setting the endpoint
      * address URL overrides any value set for port.


### PR DESCRIPTION
Added "bridge-remote-transaction" flag as a sca component property to set if transaction should be propagated through the remote SCA invocation.
