### PR TITLE
SWITCHYARD-2114

### DIFF
--- a/karaf/features/src/main/resources/features.xml
+++ b/karaf/features/src/main/resources/features.xml
@@ -81,6 +81,28 @@
         <bundle>wrap:mvn:net.sf.dozer/dozer/${version.net.sf.dozer}</bundle>
     </feature>
 
+    <feature name="switchyard-camel-jpa-hibernate" version="${project.version}" resolver="(obr)">
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-annotation_1.0_spec/1.1.1</bundle>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jpa_2.0_spec/1.1</bundle>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-servlet_2.5_spec/1.2</bundle>
+        <feature version='[3.1,3.3)'>spring-tx</feature>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-el_1.0_spec/1.0.1</bundle>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+        <feature version='[3.1,3.3)'>spring-jdbc</feature>
+        <bundle dependency='true'>mvn:commons-lang/commons-lang/2.6</bundle>
+        <bundle dependency='true'>mvn:commons-collections/commons-collections/3.2.1</bundle>
+        <bundle dependency='true'>mvn:commons-pool/commons-pool/1.6</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-dbcp/1.4_3</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ant/1.7.0_6</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.serp/1.14.1_1</bundle>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.asm/3.3_2</bundle>
+        <feature version='${project.version}'>switchyard-hibernate</feature>
+        <feature version='[3.1,3.3)'>spring-orm</feature>
+        <feature version='${version.org.apache.camel.features}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-jpa/${version.org.apache.camel}</bundle>
+    </feature>
+
     <!-- Switchyard Components -->
 
     <feature name="switchyard-amqp" version="${project.version}" resolver="(obr)">
@@ -214,7 +236,7 @@
 
     <feature name="switchyard-jpa" version="${project.version}" resolver="(obr)">
         <feature version="${project.version}">switchyard-camel</feature>
-        <feature version="${version.org.apache.camel.features}">camel-jpa</feature>
+        <feature version="${project.version}">switchyard-camel-jpa-hibernate</feature>
         <bundle>mvn:org.switchyard.components/switchyard-component-camel-jpa/${project.version}</bundle>
     </feature>
 
@@ -447,6 +469,8 @@
         </config>
         <bundle>mvn:com.h2database/h2/${version.com.h2database}</bundle>
         <bundle>mvn:org.switchyard.quickstarts/switchyard-camel-jpa-binding/${project.version}</bundle>
+        <!-- must be after bundle using persistence -->
+        <bundle>mvn:org.hibernate/hibernate-osgi/${version.org.hibernate}</bundle>
     </feature>
 
     <feature name="switchyard-quickstart-camel-mail-binding" version="${project.version}" resolver="(obr)">


### PR DESCRIPTION
Modified camel-jpa-binding quickstart dependencies so it works with Hibernate instead of OpenJPA

Thank you @rcernich for finding a way to get work with hibernate JPA, it did work for camel-jpa-binding as well! We still need to re-package camel-jpa to remove openjpa dependency. This fix does it.
