### PR TITLE
SWITCHYARD-2015 Unify a type of name for JMS destination

### DIFF
--- a/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSReferencePhysicalName.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSReferencePhysicalName.java
@@ -1,0 +1,5 @@
+package org.switchyard.test.jca;
+
+public interface JCAJMSReferencePhysicalName {
+    public void onMessagePhysicalName(String body);
+}

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSReferenceService.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSReferenceService.java
@@ -6,4 +6,6 @@ public interface JCAJMSReferenceService {
     public void onMessageText(String body);
 
     public void onMessageContextProperty(String body) throws Exception;
+
+    public void onMessagePhysicalName(String body);
 }

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSReferenceServiceImpl.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSReferenceServiceImpl.java
@@ -19,6 +19,9 @@ public class JCAJMSReferenceServiceImpl implements JCAJMSReferenceService {
     @Inject @Reference("JCAJMSReference")
     private ReferenceInvoker referenceInvoker;
 
+    @Inject @Reference
+    private JCAJMSReferencePhysicalName servicePhysicalName;
+
     @Override
     public void onMessage(String name) {
         service.onMessage(name);
@@ -35,5 +38,10 @@ public class JCAJMSReferenceServiceImpl implements JCAJMSReferenceService {
                         .setProperty(JMSProcessor.CONTEXT_PROPERTY_PREFIX + JMSProcessor.KEY_DESTINATION, "ResultPropQueue")
                         .setProperty(JMSProcessor.CONTEXT_PROPERTY_PREFIX + JMSProcessor.KEY_MESSAGE_TYPE, "Bytes")
                         .invoke(name);
+    }
+
+    @Override
+    public void onMessagePhysicalName(String name) {
+        servicePhysicalName.onMessagePhysicalName(name);
     }
 }

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSService.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSService.java
@@ -12,4 +12,8 @@ public interface JCAJMSService {
     public String onMessage_inout_fault(String name) throws JCAJMSFault;
 
     public String onMessage_inout_context_property(String name);
+
+    public String onMessage_inout_physical_name(String name);
+
+    public String onMessage_inout_physical_name_fault(String name) throws JCAJMSFault;
 }

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSServiceImpl.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSServiceImpl.java
@@ -88,4 +88,14 @@ public class JCAJMSServiceImpl implements JCAJMSService {
         _context.setProperty(JMSEndpoint.CONTEXT_PROPERTY_PREFIX + JMSEndpoint.KEY_MESSAGE_TYPE, "Bytes", Scope.EXCHANGE);
         return name + "_replyTo";
     }
+
+    @Override
+    public String onMessage_inout_physical_name(String name) {
+        return name + "_replyTo";
+    }
+
+    @Override
+    public String onMessage_inout_physical_name_fault(String name) throws JCAJMSFault {
+        throw new JCAJMSFault(name + "_faultTo");
+    }
 }

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSTransactionService.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSTransactionService.java
@@ -10,4 +10,6 @@ public interface JCAJMSTransactionService {
     public void onMessageCamel(String body);
 
     public void onMessageContextProperty(String name) throws Exception;
+
+    public void onMessagePhysicalName(String name);
 }

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSTransactionServiceImpl.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/jca/JCAJMSTransactionServiceImpl.java
@@ -64,6 +64,15 @@ public class JCAJMSTransactionServiceImpl implements JCAJMSTransactionService {
         service.onMessageContextProperty(name);
     }
 
+    @Override
+    public void onMessagePhysicalName(String name) {
+        int txStatus = getTransactionStatus();
+        if (txStatus != Status.STATUS_ACTIVE) {
+            throw new RuntimeException("Unexpected Transaction Status: " + txStatus);
+        }
+        service.onMessagePhysicalName(name);
+    }
+
     private int getTransactionStatus() {
         try {
             InitialContext ic = new InitialContext();

--- a/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/util/ResourceDeployer.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/util/ResourceDeployer.java
@@ -38,22 +38,30 @@ public class ResourceDeployer {
     private ResourceDeployer() {
     }
     
-    public static ModelNode addQueue(final String host, final int port, final String queueName) throws IOException {
+    public static ModelNode addQueue(final String host, final int port, final String queueName, final String jndiName) throws IOException {
         final ModelControllerClient client = createClient(host, port);
         final ModelNode op = new ModelNode();
         op.get("operation").set("add");
         op.get("address").add("subsystem", "messaging");
         op.get("address").add("hornetq-server", "default");
         op.get("address").add("jms-queue", queueName);
-        op.get("entries").add(queueName)
-                         .add("java:jboss/exported/jms/" + queueName);
+        op.get("entries").add(jndiName)
+                         .add("java:jboss/exported/jms/" + jndiName);
         op.get("durable").set(false);
 
         return client.execute(op);
     }
 
+    public static ModelNode addQueue(final String host, final int port, final String queueName) throws IOException {
+        return addQueue(host, port, queueName, queueName);
+    }
+
     public static ModelNode addQueue(final String queueName) throws IOException {
-        return addQueue(DEFAULT_HOST, DEFAULT_PORT, queueName);
+        return addQueue(DEFAULT_HOST, DEFAULT_PORT, queueName, queueName);
+    }
+
+    public static ModelNode addQueue(final String queueName, final String jndiName) throws IOException {
+        return addQueue(DEFAULT_HOST, DEFAULT_PORT, queueName, jndiName);
     }
 
     public static ModelNode removeQueue(final String host, final int port, final String queueName) throws IOException {

--- a/jboss-as7/tests/src/test/resources/org/switchyard/test/jca/switchyard-inbound-jms-test.xml
+++ b/jboss-as7/tests/src/test/resources/org/switchyard/test/jca/switchyard-inbound-jms-test.xml
@@ -59,6 +59,27 @@
                    <transacted>true</transacted>
                </inboundInteraction>
             </binding.jca>
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <operationSelector.regex xmlns="urn:switchyard-config:switchyard:1.0" expression="onMessage.*"/>
+               <inboundConnection>
+                   <resourceAdapter name="hornetq-ra.rar"/>
+                   <activationSpec>
+                       <property name="destinationType" value="javax.jms.Queue"/>
+                       <property name="destination" value="queue/InOutPhysicalNameTestQueue_physical"/>
+                   </activationSpec>
+               </inboundConnection>
+               <inboundInteraction>
+                   <listener>javax.jms.MessageListener</listener>
+                   <endpoint type="org.switchyard.component.jca.endpoint.JMSEndpoint">
+                       <property name="destinationType" value="javax.jms.Queue"/>
+                       <property name="replyTo" value="InOutPhysicalNameTestQueue_replyTo_physical"/>
+                       <property name="faultTo" value="InOutPhysicalNameTestQueue_faultTo_physical"/>
+                       <property name="messageType" value="Text"/>
+                       <property name="connectionFactoryJNDIName" value="java:/JmsXA"/>
+                   </endpoint>
+                   <transacted>true</transacted>
+               </inboundInteraction>
+            </binding.jca>
         </sca:service>
         <sca:reference name="JCAJMSStoreResult" promote="ComponentName/JCAJMSStoreResult" multiplicity="1..1">
             <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">

--- a/jboss-as7/tests/src/test/resources/org/switchyard/test/jca/switchyard-outbound-jms-test.xml
+++ b/jboss-as7/tests/src/test/resources/org/switchyard/test/jca/switchyard-outbound-jms-test.xml
@@ -87,6 +87,23 @@
                </outboundInteraction>
             </binding.jca>
         </sca:reference>
+        <sca:reference name="JCAJMSReferencePhysicalName" promote="JCAReferenceComponent/JCAJMSReferencePhysicalName" multiplicity="1..1">
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <jca:contextMapper class="org.switchyard.test.jca.MyJMSContextMapper"/>
+               <jca:messageComposer class="org.switchyard.test.jca.MyJMSMessageComposer"/>
+               <outboundConnection>
+                   <resourceAdapter name="hornetq-ra.rar"/>
+                   <connection jndiName="java:/JmsXA"/>
+               </outboundConnection>
+               <outboundInteraction>
+                   <processor type="org.switchyard.component.jca.processor.JMSProcessor">
+                       <property name="destinationType" value="javax.jms.Queue"/>
+                       <property name="destination" value="ResultPhysicalNameQueue_physical"/>
+                       <property name="messageType" value="Text"/>
+                   </processor>
+               </outboundInteraction>
+            </binding.jca>
+        </sca:reference>
         <sca:reference name="CamelJCAJMSReference" promote="CamelComponent/CamelJCAJMSReference" multiplicity="1..1">
             <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
                <contextMapper includes=".*"/>
@@ -125,6 +142,9 @@
             </sca:reference>
             <sca:reference name="JCAJMSReferenceText">
                 <sca:interface.java interface="org.switchyard.test.jca.JCAJMSReferenceText"/>
+            </sca:reference>
+            <sca:reference name="JCAJMSReferencePhysicalName">
+                <sca:interface.java interface="org.switchyard.test.jca.JCAJMSReferencePhysicalName"/>
             </sca:reference>
         </sca:component>
         


### PR DESCRIPTION
Fixed to use physical name for the destination on replyTo/faultTo for inbound and destination for outbound. replyToType, faultType and destinationType has been added to the property.
This includes a fix for "SWITCHYARD-2267 Remove transacted and acknowledgeMode from outbound JCA" as well.
