### PR TITLE
SWITCHYARD-2382 JCA binding throws NPE if property value is empty or not...

### DIFF
--- a/jboss-as7/tests/src/test/resources/org/switchyard/test/jca/switchyard-inbound-jms-test.xml
+++ b/jboss-as7/tests/src/test/resources/org/switchyard/test/jca/switchyard-inbound-jms-test.xml
@@ -31,6 +31,7 @@
                    <activationSpec>
                        <property name="destinationType" value="javax.jms.Queue"/>
                        <property name="destination" value="queue/TestQueue"/>
+                       <property name="messageSelector"/>
                    </activationSpec>
                </inboundConnection>
                <inboundInteraction>


### PR DESCRIPTION
... specified
