### PR TITLE
SWITCHYARD-2447 Remove deltaspike version from release/karaf/features PO...

### DIFF
--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -31,7 +31,6 @@
         <version.commons-beanutils>1.8.3</version.commons-beanutils>
         <version.org.apache.xbean>3.12</version.org.apache.xbean>
         <version.org.jboss.logging>3.1.2.GA</version.org.jboss.logging>
-        <version.org.apache.deltaspike.core>0.4</version.org.apache.deltaspike.core>
         <version.org.apache.geronimo.specs.servlet>1.0</version.org.apache.geronimo.specs.servlet>
         <version.org.apache.servicemix.bundles.saaj-impl>1.3.9_2</version.org.apache.servicemix.bundles.saaj-impl>
         <version.org.apache.camel.features>[2.12,2.13)</version.org.apache.camel.features>


### PR DESCRIPTION
...M

Passed release/karaf/tests, and verified deltaspike 1.0.0 is actually brought when installed bean-service quickstart.
