### PR TITLE
create build profiles for eap, karaf and wildfly; cleanup test issues on wildfly

### DIFF
--- a/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/util/ResourceDeployer.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/util/ResourceDeployer.java
@@ -40,16 +40,20 @@ public class ResourceDeployer {
     
     public static ModelNode addQueue(final String host, final int port, final String queueName, final String jndiName) throws IOException {
         final ModelControllerClient client = createClient(host, port);
-        final ModelNode op = new ModelNode();
-        op.get("operation").set("add");
-        op.get("address").add("subsystem", "messaging");
-        op.get("address").add("hornetq-server", "default");
-        op.get("address").add("jms-queue", queueName);
-        op.get("entries").add(jndiName)
-                         .add("java:jboss/exported/jms/" + jndiName);
-        op.get("durable").set(false);
-
-        return client.execute(op);
+        try {
+            final ModelNode op = new ModelNode();
+            op.get("operation").set("add");
+            op.get("address").add("subsystem", "messaging");
+            op.get("address").add("hornetq-server", "default");
+            op.get("address").add("jms-queue", queueName);
+            op.get("entries").add(jndiName)
+                             .add("java:jboss/exported/jms/" + jndiName);
+            op.get("durable").set(false);
+    
+            return client.execute(op);
+        } finally {
+            client.close();
+        }
     }
 
     public static ModelNode addQueue(final String host, final int port, final String queueName) throws IOException {
@@ -66,12 +70,16 @@ public class ResourceDeployer {
 
     public static ModelNode removeQueue(final String host, final int port, final String queueName) throws IOException {
         final ModelControllerClient client = createClient(host, port);
-        final ModelNode op = new ModelNode();
-        op.get("operation").set("remove");
-        op.get("address").add("subsystem", "messaging");
-        op.get("address").add("hornetq-server", "default");
-        op.get("address").add("jms-queue", queueName);
-        return client.execute(op);
+        try {
+            final ModelNode op = new ModelNode();
+            op.get("operation").set("remove");
+            op.get("address").add("subsystem", "messaging");
+            op.get("address").add("hornetq-server", "default");
+            op.get("address").add("jms-queue", queueName);
+            return client.execute(op);
+        } finally {
+            client.close();
+        }
     }
 
     public static ModelNode removeQueue(final String queueName) throws IOException {
@@ -80,15 +88,19 @@ public class ResourceDeployer {
 
     public static ModelNode addPooledConnectionFactory(final String host, final int port, final String cfName, final boolean xa, final String jndiName) throws IOException {
         final ModelControllerClient client = createClient(host, port);
-        final ModelNode op = new ModelNode();
-        op.get("operation").set("add");
-        op.get("address").add("subsystem", "messaging");
-        op.get("address").add("hornetq-server", "default");
-        op.get("address").add("pooled-connection-factory", cfName);
-        op.get("transaction").set(xa ? "xa" : "local");
-        op.get("connector").set("in-vm", "");
-        op.get("entries").add(jndiName);
-        return client.execute(op);
+        try {
+            final ModelNode op = new ModelNode();
+            op.get("operation").set("add");
+            op.get("address").add("subsystem", "messaging");
+            op.get("address").add("hornetq-server", "default");
+            op.get("address").add("pooled-connection-factory", cfName);
+            op.get("transaction").set(xa ? "xa" : "local");
+            op.get("connector").set("in-vm", "");
+            op.get("entries").add(jndiName);
+            return client.execute(op);
+        } finally {
+            client.close();
+        }
     }
 
     public static ModelNode addPooledConnectionFactory(final String cfName, final boolean xa, final String jndiName) throws IOException {
@@ -97,12 +109,16 @@ public class ResourceDeployer {
 
     public static ModelNode removePooledConnectionFactory(final String host, final int port, final String cfName) throws IOException {
         final ModelControllerClient client = createClient(host, port);
-        final ModelNode op = new ModelNode();
-        op.get("operation").set("remove");
-        op.get("address").add("subsystem", "messaging");
-        op.get("address").add("hornetq-server", "default");
-        op.get("address").add("pooled-connection-factory", cfName);
-        return client.execute(op);
+        try {
+            final ModelNode op = new ModelNode();
+            op.get("operation").set("remove");
+            op.get("address").add("subsystem", "messaging");
+            op.get("address").add("hornetq-server", "default");
+            op.get("address").add("pooled-connection-factory", cfName);
+            return client.execute(op);
+        } finally {
+            client.close();
+        }
     }
 
     public static ModelNode removePooledConnectionFactory(final String cfName) throws IOException {

--- a/jboss-as7/wildfly/dist/pom.xml
+++ b/jboss-as7/wildfly/dist/pom.xml
@@ -32,7 +32,7 @@
         <distro.file>switchyard-${project.version}-WildFly</distro.file>
         <distro.root.dir>/</distro.root.dir>
         <installer.root.dir>/switchyard-wildfly-installer-${version.distro}</installer.root.dir>
-        <switchyard.jboss.home>${staging.jboss.dir}</switchyard.jboss.home>
+        <switchyard.wildfly.home>${staging.jboss.dir}</switchyard.wildfly.home>
         <zip.file.name>${distro.file}.zip</zip.file.name>
     </properties>
     <dependencies>
@@ -308,14 +308,14 @@
                     <argLine>-Xms512m -Xmx512m</argLine>
                     <forkMode>always</forkMode>
                     <environmentVariables>
-                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                        <JBOSS_HOME>${wildfly.home}</JBOSS_HOME>
                         <SWITCHYARD_VERSION>${project.version}</SWITCHYARD_VERSION>
                     </environmentVariables>
                     <systemPropertyVariables>
                         <arquillian.launch>jboss</arquillian.launch>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <jboss.home>${jboss.home}</jboss.home>
-                        <module.path>${jboss.home}/modules</module.path>
+                        <jboss.home>${wildfly.home}</jboss.home>
+                        <module.path>${wildfly.home}/modules</module.path>
                     </systemPropertyVariables>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
                     <excludes>
@@ -338,18 +338,18 @@
             <id>default</id>
             <activation>
                 <property>
-                    <name>!jboss.home</name>
+                    <name>!wildfly.home</name>
                 </property>
             </activation>
             <properties>
-                <jboss.home>${switchyard.jboss.home}</jboss.home>
+                <wildfly.home>${switchyard.wildfly.home}</wildfly.home>
             </properties>
         </profile>
         <profile>
             <id>manual</id>
             <activation>
                 <property>
-                    <name>jboss.home</name>
+                    <name>wildfly.home</name>
                 </property>
             </activation>
             <build>
@@ -363,9 +363,9 @@
                                 <phase>process-test-resources</phase>
                                 <configuration>
                                     <tasks>
-                                        <unzip dest="${jboss.home}" src="${project.build.directory}/${zip.file.name}"/>
-                                        <copy file="${staging.jboss.dir}/standalone/configuration/application-users.properties" todir="${jboss.home}/standalone/configuration"/>
-                                        <copy file="${staging.jboss.dir}/standalone/configuration/application-roles.properties" todir="${jboss.home}/standalone/configuration"/>
+                                        <unzip dest="${wildfly.home}" src="${project.build.directory}/${zip.file.name}"/>
+                                        <copy file="${staging.jboss.dir}/standalone/configuration/application-users.properties" todir="${wildfly.home}/standalone/configuration"/>
+                                        <copy file="${staging.jboss.dir}/standalone/configuration/application-roles.properties" todir="${wildfly.home}/standalone/configuration"/>
                                     </tasks>
                                 </configuration>
                                 <goals>

--- a/jboss-as7/wildfly/dist/src/test/resources/arquillian.xml
+++ b/jboss-as7/wildfly/dist/src/test/resources/arquillian.xml
@@ -9,6 +9,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="serverConfig">../../../../test-classes/standalone-test.xml</property>
+            <property name="javaVmArguments">-Xms256m -Xmx1024m -XX:MaxPermSize=512m</property>
         </configuration>
     </container>
     <!--<engine>

--- a/jboss-as7/wildfly/dist/src/test/resources/standalone-test.xml
+++ b/jboss-as7/wildfly/dist/src/test/resources/standalone-test.xml
@@ -121,6 +121,12 @@
             <logger category="jacorb.config">
                 <level name="ERROR"/>
             </logger>
+            <logger category="org.switchyard">
+                <level name="INFO"/>
+            </logger>
+            <logger category="org.apache.deltaspike.core.api.provider.BeanManagerProvider">
+                <level name="ERROR"/>
+            </logger>
             <root-logger>
                 <level name="INFO"/>
                 <handlers>
@@ -594,8 +600,10 @@
                 <module identifier="org.switchyard.component.camel.jms" implClass="org.switchyard.component.camel.jms.deploy.CamelJmsComponent"/>
                 <module identifier="org.switchyard.component.camel.jpa" implClass="org.switchyard.component.camel.jpa.deploy.CamelJpaComponent"/>
                 <module identifier="org.switchyard.component.camel.mail" implClass="org.switchyard.component.camel.mail.deploy.CamelMailComponent"/>
+                <module identifier="org.switchyard.component.camel.mqtt" implClass="org.switchyard.component.camel.mqtt.deploy.CamelMqttComponent"/>
                 <module identifier="org.switchyard.component.camel.netty" implClass="org.switchyard.component.camel.netty.deploy.CamelNettyComponent"/>
                 <module identifier="org.switchyard.component.camel.quartz" implClass="org.switchyard.component.camel.quartz.deploy.CamelQuartzComponent"/>
+                <module identifier="org.switchyard.component.camel.rss" implClass="org.switchyard.component.camel.rss.deploy.CamelRSSComponent"/>
                 <module identifier="org.switchyard.component.camel.sql" implClass="org.switchyard.component.camel.sql.deploy.CamelSqlComponent"/>
                 <module identifier="org.switchyard.component.rules" implClass="org.switchyard.component.rules.deploy.RulesComponent"/>
                 <module identifier="org.switchyard.component.bpm" implClass="org.switchyard.component.bpm.deploy.BPMComponent"/>
@@ -618,6 +626,7 @@
                 <extension identifier="org.apache.camel.mvel"/>
                 <extension identifier="org.apache.camel.ognl"/>
                 <extension identifier="org.apache.camel.jaxb"/>
+                <extension identifier="org.apache.camel.saxon"/>
                 <extension identifier="org.apache.camel.soap"/>
             </extensions>
         </subsystem>

--- a/jboss-as7/wildfly/pom.xml
+++ b/jboss-as7/wildfly/pom.xml
@@ -26,14 +26,9 @@
     <description>SwitchYard Wildfly Standalone Parent</description>
     <properties>
         <version.wildfly>8.0.0.Final</version.wildfly>
-        <version.shrinkwrap>1.1.2</version.shrinkwrap>
-        <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
-        <version.shrinkwrap.descriptors>2.0.0-alpha-3</version.shrinkwrap.descriptors>
         <!-- Required for the module.xml file generation. -->
         <version.io.netty>3.6.6.Final</version.io.netty>
         <!-- Overridden version settings. -->
-        <version.arquillian.container>1.1.2.Final-wildfly-1</version.arquillian.container>
-        <version.jbossws.spi>2.2.2.Final</version.jbossws.spi>
     </properties>
     <modules>
         <module>extension</module>
@@ -57,39 +52,6 @@
                 <artifactId>wildfly-dist</artifactId>
                 <type>zip</type>
                 <version>${version.wildfly}</version>
-            </dependency>
-            <!--<dependency>
-                <groupId>org.jboss.arquillian.protocol</groupId>
-                <artifactId>arquillian-protocol-servlet</artifactId>
-                <version>${version.arquillian.container}</version>
-            </dependency>-->
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.arquillian.container}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-bom</artifactId>
-                <type>pom</type>
-                <scope>import</scope>
-                <version>${version.shrinkwrap}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-                <artifactId>shrinkwrap-descriptors-bom</artifactId>
-                <type>pom</type>
-                <scope>import</scope>
-                <version>${version.shrinkwrap.descriptors}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <type>pom</type>
-                <scope>import</scope>
-                <version>${version.shrinkwrap.resolver}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
     <modules>
         <module>testutil</module>
         <module>distribution</module>
-        <module>jboss-as7</module>
-        <module>karaf</module>
         <module>tools/dist</module>
         <module>admin/rhq</module>
         <module>installer</module>
@@ -81,4 +79,42 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>eap</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>jboss-as7</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>wildfly</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>jboss-as7</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>karaf</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>karaf</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>openshift</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>jboss-as7</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Project can now be built for any or all distibutions: eap, karaf and wildfly.  The wildfly build now uses wildfly.home instead of jboss.home, which allows it to be built at the same time as eap.  Currently, the default is to build eap and karaf (same as before).
