### PR TITLE
SWITCHYARD-2399 Seeing conflict in deltaspike dependencies between switchyard-common-cdi and camel-cdi

### DIFF
--- a/jboss-as7/modules/pom.xml
+++ b/jboss-as7/modules/pom.xml
@@ -528,7 +528,17 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cdi</artifactId>
-        </dependency>
+            <exclusions>
+                <exclusion>
+                    <artifactId>deltaspike-core-impl</artifactId>
+                    <groupId>org.apache.deltaspike.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>deltaspike-cdictrl-api</artifactId>
+                    <groupId>org.apache.deltaspike.cdictrl</groupId>
+                </exclusion>
+            </exclusions>
+  	</dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring</artifactId>


### PR DESCRIPTION
Exclude deltaspike from camel-cdi.
