### PR TITLE
SWITCHYARD-2498: Adding FILE / THREADED_FILE Logger leads to "ava.lang.ClassNotFoundException: org.xmlpull.v1.XmlPullParserException"

### DIFF
--- a/jboss-as7/modules/src/main/resources/external/xstream/module.xml
+++ b/jboss-as7/modules/src/main/resources/external/xstream/module.xml
@@ -20,5 +20,8 @@
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="sun.jdk" optional="true"/>
+        <module name="xmlpull" optional="true"/>
+        <module name="xpp3" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
SWITCHYARD-2498: Adding FILE / THREADED_FILE Logger leads to "ava.lang.ClassNotFoundException: org.xmlpull.v1.XmlPullParserException"
https://issues.jboss.org/browse/SWITCHYARD-2498