### PR TITLE
SWITCHYARD-2645 org.switchyard.test.quickstarts.HttpBindingQuickstartTes...

### DIFF
--- a/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/HttpBindingQuickstartTest.java
+++ b/jboss-as7/tests/src/test/java/org/switchyard/test/quickstarts/HttpBindingQuickstartTest.java
@@ -91,7 +91,7 @@ public class HttpBindingQuickstartTest {
         httpMixIn.initialize();
         try {
             String response = httpMixIn.sendString(BASE_URL + "/symbol", "headers", HTTPMixIn.HTTP_POST);
-            Assert.assertTrue(response.toLowerCase().indexOf("content-type=text/xml; charset=utf-8") > 0);
+            Assert.assertTrue("Unexpected response: [" + response + "]", response.toLowerCase().indexOf("content-type=text/xml; charset=utf-8") >= 0);
             int status = httpMixIn.sendStringAndGetStatus(BASE_URL + "/symbol", "rum", HTTPMixIn.HTTP_POST);
             Assert.assertEquals(404, status);
         } finally {


### PR DESCRIPTION
...t failing on Wildfly

Assertion fails if Content-type is the first header in response, as indexOf() returns 0