### PR TITLE
SWITCHYARD-2649 Cannot deploy demos/helpdesk on Wildfly 8.0

### DIFF
--- a/jboss-as7/wildfly/dist/pom.xml
+++ b/jboss-as7/wildfly/dist/pom.xml
@@ -341,14 +341,6 @@
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
                     <excludes>
                         <exclude>**/*$*</exclude>
-                        <exclude>**/BPMServiceQuickstartTest*</exclude>
-                        <exclude>**/RulesInterviewQuickstartTest*</exclude>
-                        <exclude>**/RemoteInvokerQuickstartTest*</exclude>
-                        <exclude>**/RulesCamelCBRQuickstartTest*</exclude>
-                        <exclude>**/RulesInterviewContainerQuickstartTest*</exclude>
-                        <exclude>**/RulesInterviewDTableQuickstartTest*</exclude>
-                        <exclude>**/HelpDeskDemoQuickstartTest*</exclude>
-                        <exclude>**/LibraryDemoQuickstartTest*</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/jboss-as7/wildfly/modules/assembly.xml
+++ b/jboss-as7/wildfly/modules/assembly.xml
@@ -29,6 +29,7 @@
             <excludes>
                 <exclude>system/layers/soa/org/switchyard/main/*.*</exclude>
                 <exclude>system/layers/soa/org/switchyard/component/bpel/main/module.xml</exclude>
+                <exclude>system/layers/soa/org/switchyard/component/common/knowledge/main/module.xml</exclude>
                 <exclude>system/layers/soa/org/jboss/as/console/eap/*.*</exclude>
             </excludes>
         </fileSet>
@@ -40,6 +41,7 @@
     <componentDescriptors>
       <componentDescriptor>src/main/resources/switchyard/core/assembly-component.xml</componentDescriptor>
       <componentDescriptor>src/main/resources/switchyard/components/bpel/assembly-component.xml</componentDescriptor>
+      <componentDescriptor>src/main/resources/switchyard/components/common/knowledge/assembly-component.xml</componentDescriptor>
       <componentDescriptor>src/main/resources/switchyard/console/assembly-component.xml</componentDescriptor>
       <componentDescriptor>src/main/resources/external/jboss/as/osgi/jta/assembly-component.xml</componentDescriptor>
       <componentDescriptor>src/main/resources/external/jboss/netty/assembly-component.xml</componentDescriptor>

--- a/jboss-as7/wildfly/modules/src/main/resources/switchyard/components/common/knowledge/assembly-component.xml
+++ b/jboss-as7/wildfly/modules/src/main/resources/switchyard/components/common/knowledge/assembly-component.xml
@@ -1,0 +1,26 @@
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+<component xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.2 http://maven.apache.org/xsd/component-1.1.2.xsd">
+
+    <files>
+        <file>
+            <source>src/main/resources/switchyard/components/common/knowledge/resources/module.xml</source>
+            <outputDirectory>/modules/system/layers/soa/org/switchyard/component/common/knowledge/main</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+    </files>
+    <dependencySets>
+    </dependencySets>
+</component>

--- a/jboss-as7/wildfly/modules/src/main/resources/switchyard/components/common/knowledge/resources/module.xml
+++ b/jboss-as7/wildfly/modules/src/main/resources/switchyard/components/common/knowledge/resources/module.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.0" name="org.switchyard.component.common.knowledge">
+    <resources>
+        <resource-root path="switchyard-component-common-knowledge-${project.version}.jar"/>
+    </resources>
+    <dependencies>
+        <module name="com.google.protobuf"/>
+        <module name="javax.api"/>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.persistence.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.drools" export="true"/>
+        <module name="org.hibernate"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jbpm" export="true">
+            <imports>
+                <include path="META-INF/services"/>
+                <exclude path="META-INF/beans.xml"/>
+            </imports>
+            <exports>
+                <include path="META-INF/services"/>
+                <exclude path="META-INF/beans.xml"/>
+            </exports>
+        </module>
+        <module name="org.kie" export="true"/>
+        <module name="org.kie.remote" services="import"/>
+        <module name="org.mvel"/>
+        <module name="org.switchyard"/>
+        <module name="org.switchyard.api"/>
+        <module name="org.switchyard.common"/>
+        <module name="org.switchyard.component.common"/>
+        <module name="org.switchyard.config"/>
+        <module name="org.switchyard.deploy"/>
+        <module name="org.switchyard.serial"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
Fixed module.xml to make AbstractJtaPlatform wrapper visible to components/common/knowledge. Also re-enabled drools related quickstart tests for wildfly.